### PR TITLE
Fix URLs/UMAP for CV Monitoring

### DIFF
--- a/quickstart/latest/Fiddler_Quickstart_Image_Monitoring.ipynb
+++ b/quickstart/latest/Fiddler_Quickstart_Image_Monitoring.ipynb
@@ -1,723 +1,725 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "18a75022",
-      "metadata": {
-        "id": "18a75022"
-      },
-      "source": [
-        "# Monitoring Image data using Fiddler Vector Monitoring\n",
-        "\n",
-        "In this notebook we present the steps for monitoring images. Fiddler employs a vector-based monitoring approach that can be used to monitor data drift in high-dimensional data such as NLP embeddings, images, video etc. In this notebook we demonstrate how to detect drift in image data using model embeddings and determine the cause of that drift.\n",
-        "\n",
-        "Fiddler is the pioneer in enterprise Model Performance Management (MPM), offering a unified platform that enables Data Science, MLOps, Risk, Compliance, Analytics, and LOB teams to **monitor, explain, analyze, and improve ML deployments at enterprise scale**.\n",
-        "Obtain contextual insights at any stage of the ML lifecycle, improve predictions, increase transparency and fairness, and optimize business revenue.\n",
-        "\n",
-        "---\n",
-        "\n",
-        "You can experience Fiddler's Image monitoring ***in minutes*** by following these quick steps:\n",
-        "\n",
-        "1. Connect to Fiddler\n",
-        "2. Load and generate embeddings for CIFAR-10 dataset\n",
-        "3. Upload the vectorized baseline dataset\n",
-        "4. Add metadata about your model\n",
-        "5. Inject data drift and publish production events\n",
-        "6. Get insights"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "443126a9",
-      "metadata": {
-        "id": "443126a9"
-      },
-      "source": [
-        "## Imports"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "749423fa",
-      "metadata": {
-        "id": "749423fa"
-      },
-      "outputs": [],
-      "source": [
-        "!pip install torch==2.0.0\n",
-        "!pip install torchvision==0.15.1\n",
-        "!pip install -q fiddler-client"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ce568ccb",
-      "metadata": {
-        "id": "ce568ccb"
-      },
-      "outputs": [],
-      "source": [
-        "import io\n",
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "import random\n",
-        "import time\n",
-        "import torch\n",
-        "import torch.nn as nn\n",
-        "import torchvision.transforms as transforms\n",
-        "from torchvision.models import resnet18, ResNet18_Weights\n",
-        "import requests\n",
-        "\n",
-        "import fiddler as fdl\n",
-        "print(f\"Running Fiddler client version {fdl.__version__}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e2dead36",
-      "metadata": {
-        "id": "e2dead36"
-      },
-      "source": [
-        "## 2. Connect to Fiddler\n",
-        "\n",
-        "Before you can add information about your model with Fiddler, you'll need to connect using our API client.\n",
-        "\n",
-        "\n",
-        "---\n",
-        "\n",
-        "\n",
-        "**We need a few pieces of information to get started.**\n",
-        "1. The URL you're using to connect to Fiddler\n",
-        "2. Your authorization token\n",
-        "\n",
-        "These can be found by navigating to the **Settings** page of your Fiddler environment."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a41e2e8d",
-      "metadata": {
-        "id": "a41e2e8d"
-      },
-      "outputs": [],
-      "source": [
-        "URL = ''  # Make sure to include the full URL (including https://).\n",
-        "TOKEN = ''"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "024b0fda",
-      "metadata": {
-        "id": "024b0fda"
-      },
-      "source": [
-        "Now just run the following code block to connect to the Fiddler API!"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "627e583c",
-      "metadata": {
-        "id": "627e583c"
-      },
-      "outputs": [],
-      "source": [
-        "fdl.init(\n",
-        "    url=URL,\n",
-        "    token=TOKEN\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "3c513f82",
-      "metadata": {
-        "id": "3c513f82"
-      },
-      "source": [
-        "Once you connect, you can create a new project by calling a Project's `create` method."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "b3db485e",
-      "metadata": {
-        "id": "b3db485e"
-      },
-      "outputs": [],
-      "source": [
-        "PROJECT_NAME = 'image_monitoring'\n",
-        "\n",
-        "project = fdl.Project(\n",
-        "    name=PROJECT_NAME\n",
-        ")\n",
-        "\n",
-        "project.create()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "19011830",
-      "metadata": {
-        "id": "19011830"
-      },
-      "source": [
-        "## 2. Generate Embeddings for CIFAR-10 data\n",
-        "\n",
-        "In this example, we'll use the popular CIFAR-10 classification dataset and a model based on Resnet-18 architecture. For the purpose of this example we have pre-trained the model.\n",
-        "  \n",
-        "In order to compute data and prediction drift, **Fiddler needs a sample of data that can serve as a baseline** for making comparisons with data in production. When it comes to computing distributional shift for images, Fiddler relies on the model's intermediate representations also known as activations or embeddings. You can read more about our approach [here](https://www.fiddler.ai/blog/monitoring-natural-language-processing-and-computer-vision-models-part-1).\n",
-        "\n",
-        "In the the following cells we'll extract these embeddings."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6db22a69",
-      "metadata": {
-        "id": "6db22a69"
-      },
-      "outputs": [],
-      "source": [
-        "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
-        "print(f'Device to be used: {device}')"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "94ecb2a6",
-      "metadata": {
-        "id": "94ecb2a6"
-      },
-      "source": [
-        "Let us load the pre-trained model"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "94f288a2",
-      "metadata": {
-        "id": "94f288a2"
-      },
-      "outputs": [],
-      "source": [
-        "MODEL_URL='https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/models/resnet18_cifar10_epoch5.pth'\n",
-        "MODEL_PATH='resnet18_cifar10_epoch5.pth'\n",
-        "\n",
-        "def load_model(device):\n",
-        "    \"\"\"Loads the pre-trained CIFAR-10 model\"\"\"\n",
-        "    model = resnet18()\n",
-        "    model.fc = nn.Sequential(\n",
-        "        nn.Linear(512, 128),\n",
-        "        nn.ReLU(),\n",
-        "        nn.Linear(128, 10),\n",
-        "    )\n",
-        "\n",
-        "    r = requests.get(MODEL_URL)\n",
-        "    with open(MODEL_PATH,'wb') as f:\n",
-        "        f.write(r.content)\n",
-        "\n",
-        "    model.load_state_dict(torch.load(MODEL_PATH, map_location=torch.device(device)))\n",
-        "    model.to(device)\n",
-        "    return model\n",
-        "\n",
-        "resnet_model = load_model(device)\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1ad83d0d",
-      "metadata": {
-        "id": "1ad83d0d"
-      },
-      "source": [
-        "We'll load four tranches of [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) data for this example.  \"reference\" – corresponding to train-time reference data, and three \"production\" sets with diffrent transformations applied to simulate drift from the model's training data. Note that running the cell below will download the CIFAR-10 data and load them using torch's dataloaders."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "BATCH_SIZE = 32\n",
-        "\n",
-        "transform = transforms.Compose([\n",
-        "        transforms.ToTensor(),\n",
-        "        transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),\n",
-        "    ])\n",
-        "\n",
-        "DATA_BASE_URL = 'https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/data/cv_monitoring/'\n",
-        "\n",
-        "# download file from URL\n",
-        "DATA_URLS = {\n",
-        " 'reference' : DATA_BASE_URL + 'reference/image_data.npz',\n",
-        "'production_1': DATA_BASE_URL + 'production_1/image_data.npz', # Undrifted\n",
-        "'production_2': DATA_BASE_URL + 'production_2/image_data.npz', # Blurred\n",
-        "'production_3': DATA_BASE_URL + 'production_3/image_data.npz'} # Darkened\n",
-        "\n",
-        "\n",
-        "def get_dataloader(dataset):\n",
-        "  response = requests.get(DATA_URLS[dataset])\n",
-        "  data = np.load(io.BytesIO(response.content))\n",
-        "\n",
-        "  images = [transform(x) for x in data['arr_0']]\n",
-        "  labels = data['arr_1']\n",
-        "\n",
-        "  tuple_list = list(zip(images, labels))\n",
-        "\n",
-        "  return torch.utils.data.DataLoader(\n",
-        "      tuple_list,\n",
-        "      batch_size=BATCH_SIZE,\n",
-        "      shuffle=False,\n",
-        "      num_workers=2\n",
-        "  )\n",
-        "\n",
-        "get_dataloader('reference')"
-      ],
-      "metadata": {
-        "id": "BIaNR9dKW85v"
-      },
-      "id": "BIaNR9dKW85v",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f6effa9e",
-      "metadata": {
-        "id": "f6effa9e"
-      },
-      "source": [
-        "***In the cell below we define functions that will extract the 128-dimensional embedding from the FC1 layer of the model and package them in a dataframe along with predictions, ground-truth labels, and image URLs***"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9077f38f",
-      "metadata": {
-        "id": "9077f38f"
-      },
-      "outputs": [],
-      "source": [
-        "from copy import deepcopy\n",
-        "import matplotlib.pyplot as plt\n",
-        "import numpy as np\n",
-        "\n",
-        "import torch\n",
-        "import torch.nn.functional as F\n",
-        "import torchvision.transforms as transforms\n",
-        "\n",
-        "torch.manual_seed(0)\n",
-        "\n",
-        "CIFAR_CLASSES = (\n",
-        "    'plane', 'car', 'bird', 'cat',\n",
-        "    'deer', 'dog', 'frog',\n",
-        "    'horse', 'ship', 'truck',\n",
-        ")\n",
-        "\n",
-        "global view_fc1_output_embeds\n",
-        "\n",
-        "def fc1_hook_func(model, input, output):\n",
-        "    global view_fc1_output_embeds\n",
-        "    view_fc1_output_embeds = output\n",
-        "\n",
-        "def idx_to_classes(target_arr):\n",
-        "    return [CIFAR_CLASSES[int(i)] for i in target_arr]\n",
-        "\n",
-        "def generate_embeddings(model, device, dataset_name):\n",
-        "    \"\"\"Generate embeddings for the inout images\"\"\"\n",
-        "\n",
-        "    dataloader = get_dataloader(dataset_name)\n",
-        "\n",
-        "    fc1_embeds = []\n",
-        "    output_scores = []\n",
-        "    target = []\n",
-        "\n",
-        "    with torch.no_grad():\n",
-        "        model = model.eval()\n",
-        "        fc1_module = model.fc[0]\n",
-        "        fc1_hook = fc1_module.register_forward_hook(fc1_hook_func)\n",
-        "        correct_preds = 0\n",
-        "        total_preds = 0\n",
-        "\n",
-        "        try:\n",
-        "            for inputs, labels in dataloader:\n",
-        "                inputs = inputs.to(device)\n",
-        "                labels = labels.to(device)\n",
-        "                outputs = model(inputs)\n",
-        "                outputs_smax = F.softmax(outputs, dim=1)\n",
-        "                _, preds = torch.max(outputs, 1)\n",
-        "                correct_preds += torch.sum(preds == labels.data).cpu().numpy()\n",
-        "                total_preds += len(inputs)\n",
-        "\n",
-        "                fc1_embeds.append(view_fc1_output_embeds.cpu().detach().numpy())\n",
-        "                output_scores.append(outputs_smax.cpu().detach().numpy())\n",
-        "                target.append(labels.cpu().detach().numpy())\n",
-        "\n",
-        "            fc1_embeds = np.concatenate(fc1_embeds)\n",
-        "            output_scores = np.concatenate(output_scores)\n",
-        "            target = np.concatenate(target)\n",
-        "\n",
-        "        except Exception as e:\n",
-        "            fc1_hook.remove()\n",
-        "            raise\n",
-        "\n",
-        "        print(f'{correct_preds}/{total_preds}: {100*correct_preds/total_preds:5.1f}% correct predictions.')\n",
-        "\n",
-        "    embs = deepcopy(fc1_embeds)\n",
-        "    labels = idx_to_classes(target)\n",
-        "    embedding_cols = ['emb_'+str(i) for i in range(128)]\n",
-        "    baseline_embeddings = pd.DataFrame(embs, columns=embedding_cols)\n",
-        "\n",
-        "    columns_to_combine = baseline_embeddings.columns\n",
-        "    baseline_embeddings = baseline_embeddings.apply(lambda row: row[columns_to_combine].tolist(), axis=1).to_frame()\n",
-        "    baseline_embeddings = baseline_embeddings.rename(columns={baseline_embeddings.columns[0]: 'embeddings'})\n",
-        "\n",
-        "    baseline_predictions = pd.DataFrame(output_scores, columns=CIFAR_CLASSES)\n",
-        "    baseline_labels = pd.DataFrame(labels, columns=['target'])\n",
-        "    embeddings_df = pd.concat(\n",
-        "        [baseline_embeddings, baseline_predictions, baseline_labels],\n",
-        "        axis='columns',\n",
-        "        ignore_index=False\n",
-        "    )\n",
-        "\n",
-        "    embeddings_df['image_url'] = embeddings_df.apply(lambda row:DATA_BASE_URL + dataset_name + '/' + str(row.name) + '.png', axis=1)\n",
-        "\n",
-        "\n",
-        "    return embeddings_df\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "56726d41",
-      "metadata": {
-        "id": "56726d41"
-      },
-      "source": [
-        "We'll now extract the embeddings for training data which will serve as baseline for monitoring."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "sample_df = generate_embeddings(resnet_model, device, 'reference')\n",
-        "sample_df.head()"
-      ],
-      "metadata": {
-        "id": "WXwRTqVPgJ10"
-      },
-      "id": "WXwRTqVPgJ10",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "id": "47edf8eb",
-      "metadata": {
-        "id": "47edf8eb"
-      },
-      "source": [
-        "# 4. Add metadata about the model\n",
-        "\n",
-        "Next we must tell Fiddler a bit more about our model.  This is done by by creating defining some information about our model's task, inputs, output, target and which features form the image embedding and then creating a `Model` object.\n",
-        "\n",
-        "Let's first define our Image vector using the API below."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "205af1a0",
-      "metadata": {
-        "id": "205af1a0"
-      },
-      "outputs": [],
-      "source": [
-        "image_embedding_feature = fdl.ImageEmbedding(\n",
-        "    name='image_feature',\n",
-        "    source_column='image_url',\n",
-        "    column='embeddings',\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "a57898d3",
-      "metadata": {
-        "id": "a57898d3"
-      },
-      "source": [
-        "Now let's define a `ModelSpec` object with information about the columns in our data sample."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4dd70f23-49f2-46a9-96a4-fb3ae341e892",
-      "metadata": {
-        "id": "4dd70f23-49f2-46a9-96a4-fb3ae341e892"
-      },
-      "outputs": [],
-      "source": [
-        "model_spec = fdl.ModelSpec(\n",
-        "    inputs=['embeddings'],\n",
-        "    outputs=CIFAR_CLASSES,\n",
-        "    targets=['target'],\n",
-        "    metadata=['image_url'],\n",
-        "    custom_features=[image_embedding_feature],\n",
-        ")\n",
-        "\n",
-        "timestamp_column = 'timestamp'"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "162fcae1-1ad9-4a88-9f20-d13070d45389",
-      "metadata": {
-        "id": "162fcae1-1ad9-4a88-9f20-d13070d45389"
-      },
-      "source": [
-        "Then let's specify some information about the model task."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c5050744-1528-4ba3-954e-1a6306a8d44e",
-      "metadata": {
-        "id": "c5050744-1528-4ba3-954e-1a6306a8d44e"
-      },
-      "outputs": [],
-      "source": [
-        "model_task = fdl.ModelTask.MULTICLASS_CLASSIFICATION\n",
-        "\n",
-        "task_params = fdl.ModelTaskParams(target_class_order=list(CIFAR_CLASSES))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "6a7110b2",
-      "metadata": {
-        "id": "6a7110b2"
-      },
-      "source": [
-        "Then we create a `Model` schema using the example data."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "43e75271",
-      "metadata": {
-        "id": "43e75271"
-      },
-      "outputs": [],
-      "source": [
-        "MODEL_NAME = 'resnet18'\n",
-        "\n",
-        "model = fdl.Model.from_data(\n",
-        "    name=MODEL_NAME,\n",
-        "    project_id=fdl.Project.from_name(PROJECT_NAME).id,\n",
-        "    source=sample_df,\n",
-        "    spec=model_spec,\n",
-        "    task=model_task,\n",
-        "    task_params=task_params,\n",
-        "    event_ts_col=timestamp_column\n",
-        ")\n",
-        "\n",
-        "model.create()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Additionally, let's publish the baseline data so we can use it as a reference for measuring drift and to compare production data with in Embedding Visualization for root-cause analysis."
-      ],
-      "metadata": {
-        "id": "xoAJEkK-iXwY"
-      },
-      "id": "xoAJEkK-iXwY"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "model.publish(\n",
-        "    source=sample_df,\n",
-        "    environment=fdl.EnvType.PRE_PRODUCTION,\n",
-        "    dataset_name='train_time_reference',\n",
-        ")"
-      ],
-      "metadata": {
-        "id": "cian7DBwuU4B"
-      },
-      "id": "cian7DBwuU4B",
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "id": "cff619a6",
-      "metadata": {
-        "id": "cff619a6"
-      },
-      "source": [
-        "# 5. Publish events to Fiddler\n",
-        "We'll publish events over past 3 weeks.\n",
-        "\n",
-        "- Week 1: We publish CIFAR-10 test set, which would signify no distributional shift\n",
-        "- Week 2: We publish **blurred** CIFAR-10 test set\n",
-        "- Week 3: We publish **brightness reduced** CIFAR-10 test set"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "db89da28",
-      "metadata": {
-        "id": "db89da28"
-      },
-      "outputs": [],
-      "source": [
-        "for i, dataset_name in enumerate(['production_1', 'production_2', 'production_3']):\n",
-        "    week_days = 6\n",
-        "    prod_df = generate_embeddings(resnet_model, device, dataset_name)\n",
-        "    week_offset = (2-i)*7*24*60*60*1e3\n",
-        "    day_offset = 24*60*60*1e3\n",
-        "    print(f'Publishing events from {dataset_name} transformation for week {i+1}.')\n",
-        "    for day in range(week_days):\n",
-        "        now = time.time() * 1000\n",
-        "        timestamp = int(now - week_offset - day*day_offset)\n",
-        "        events_df = prod_df.sample(1000)\n",
-        "        events_df['timestamp'] = timestamp\n",
-        "        model.publish(events_df)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "eb57a1fd",
-      "metadata": {
-        "id": "eb57a1fd"
-      },
-      "source": [
-        "## 6. Get insights\n",
-        "\n",
-        "**You're all done!**\n",
-        "  \n",
-        "You can now head to your Fiddler URL and start getting enhanced observability into your model's performance."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "45cebc85",
-      "metadata": {
-        "id": "45cebc85"
-      },
-      "source": [
-        "Fiddler can now track your image drift over time based on the embedding vectors of the images published into the platform.\n",
-        "\n",
-        "While we saw performace degrade for the various drifted data sets (this can also be plotted in tehe Monitoring chart), embedding drift doesn't require ground-truth labels as with performance metrics and often serves as a useful proxy that can indicate a problem or degraded performance.\n",
-        "\n",
-        "Please visit your Fiddler environment upon completion to check this out for yourself."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c9dd52c2-8df7-427a-aa65-cde58eb07e43",
-      "metadata": {
-        "id": "c9dd52c2-8df7-427a-aa65-cde58eb07e43"
-      },
-      "source": [
-        "<table>\n",
-        "    <tr>\n",
-        "        <td>\n",
-        "            <img src=\"https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/images/image_monitoring_2024_12_1.png\" />\n",
-        "        </td>\n",
-        "    </tr>\n",
-        "</table>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "In order to identify the root cause of data drift, Fiddler allows you to \"drill-down\" into time windows where embedding drift has been identified.  As indicated in blue in the image above, by selecting a time bin and clicking the \"Embeddings\" button, you'll be take to an Embedding Visualization chart where data from that time window is compared against reference data (e.g. `train_time_reference` that we published above) in an interactive 3D UMAP plot.\n",
-        "\n",
-        "In the image below, the embedded images in the drifted time period are semantically distinct to your model from the train-time sample.  By investigating these differents, it's easy to determine that the third \"production\" sample is darkened."
-      ],
-      "metadata": {
-        "id": "dLHr8Au8fhnh"
-      },
-      "id": "dLHr8Au8fhnh"
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "<table>\n",
-        "    <tr>\n",
-        "        <td>\n",
-        "            <img src=\"https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/images/image_monitoring_2024_12_2.png\" />\n",
-        "        </td>\n",
-        "    </tr>\n",
-        "</table>"
-      ],
-      "metadata": {
-        "id": "iVp03aS9fUXL"
-      },
-      "id": "iVp03aS9fUXL"
-    },
-    {
-      "cell_type": "markdown",
-      "id": "800aecc2",
-      "metadata": {
-        "id": "800aecc2"
-      },
-      "source": [
-        "\n",
-        "\n",
-        "---\n",
-        "\n",
-        "\n",
-        "**Questions?**  \n",
-        "  \n",
-        "Check out [our docs](https://docs.fiddler.ai/) for a more detailed explanation of what Fiddler has to offer.\n",
-        "\n",
-        "Join our [community Slack](http://fiddler-community.slack.com/) to ask any questions!\n",
-        "\n",
-        "If you're still looking for answers, fill out a ticket on [our support page](https://fiddlerlabs.zendesk.com/) and we'll get back to you shortly."
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "machine_shape": "hm",
-      "gpuType": "L4"
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12.3"
-    },
-    "accelerator": "GPU"
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "18a75022",
+   "metadata": {
+    "id": "18a75022"
+   },
+   "source": [
+    "# Monitoring Image data using Fiddler Vector Monitoring\n",
+    "\n",
+    "In this notebook we present the steps for monitoring images. Fiddler employs a vector-based monitoring approach that can be used to monitor data drift in high-dimensional data such as NLP embeddings, images, video etc. In this notebook we demonstrate how to detect drift in image data using model embeddings and determine the cause of that drift.\n",
+    "\n",
+    "Fiddler is the pioneer in enterprise Model Performance Management (MPM), offering a unified platform that enables Data Science, MLOps, Risk, Compliance, Analytics, and LOB teams to **monitor, explain, analyze, and improve ML deployments at enterprise scale**.\n",
+    "Obtain contextual insights at any stage of the ML lifecycle, improve predictions, increase transparency and fairness, and optimize business revenue.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "You can experience Fiddler's Image monitoring ***in minutes*** by following these quick steps:\n",
+    "\n",
+    "1. Connect to Fiddler\n",
+    "2. Load and generate embeddings for CIFAR-10 dataset\n",
+    "3. Upload the vectorized baseline dataset\n",
+    "4. Add metadata about your model\n",
+    "5. Inject data drift and publish production events\n",
+    "6. Get insights"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "443126a9",
+   "metadata": {
+    "id": "443126a9"
+   },
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "749423fa",
+   "metadata": {
+    "id": "749423fa"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install torch==2.0.0\n",
+    "!pip install torchvision==0.15.1\n",
+    "!pip install -q fiddler-client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce568ccb",
+   "metadata": {
+    "id": "ce568ccb"
+   },
+   "outputs": [],
+   "source": [
+    "import io\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import random\n",
+    "import time\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torchvision.transforms as transforms\n",
+    "from torchvision.models import resnet18, ResNet18_Weights\n",
+    "import requests\n",
+    "\n",
+    "import fiddler as fdl\n",
+    "print(f\"Running Fiddler client version {fdl.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2dead36",
+   "metadata": {
+    "id": "e2dead36"
+   },
+   "source": [
+    "## 2. Connect to Fiddler\n",
+    "\n",
+    "Before you can add information about your model with Fiddler, you'll need to connect using our API client.\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n",
+    "**We need a few pieces of information to get started.**\n",
+    "1. The URL you're using to connect to Fiddler\n",
+    "2. Your authorization token\n",
+    "\n",
+    "These can be found by navigating to the **Settings** page of your Fiddler environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a41e2e8d",
+   "metadata": {
+    "id": "a41e2e8d"
+   },
+   "outputs": [],
+   "source": [
+    "URL = ''  # Make sure to include the full URL (including https://).\n",
+    "TOKEN = ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "024b0fda",
+   "metadata": {
+    "id": "024b0fda"
+   },
+   "source": [
+    "Now just run the following code block to connect to the Fiddler API!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "627e583c",
+   "metadata": {
+    "id": "627e583c"
+   },
+   "outputs": [],
+   "source": [
+    "fdl.init(\n",
+    "    url=URL,\n",
+    "    token=TOKEN\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c513f82",
+   "metadata": {
+    "id": "3c513f82"
+   },
+   "source": [
+    "Once you connect, you can create a new project by calling a Project's `create` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3db485e",
+   "metadata": {
+    "id": "b3db485e"
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_NAME = 'image_monitoring'\n",
+    "\n",
+    "project = fdl.Project(\n",
+    "    name=PROJECT_NAME\n",
+    ")\n",
+    "\n",
+    "project.create()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19011830",
+   "metadata": {
+    "id": "19011830"
+   },
+   "source": [
+    "## 2. Generate Embeddings for CIFAR-10 data\n",
+    "\n",
+    "In this example, we'll use the popular CIFAR-10 classification dataset and a model based on Resnet-18 architecture. For the purpose of this example we have pre-trained the model.\n",
+    "  \n",
+    "In order to compute data and prediction drift, **Fiddler needs a sample of data that can serve as a baseline** for making comparisons with data in production. When it comes to computing distributional shift for images, Fiddler relies on the model's intermediate representations also known as activations or embeddings. You can read more about our approach [here](https://www.fiddler.ai/blog/monitoring-natural-language-processing-and-computer-vision-models-part-1).\n",
+    "\n",
+    "In the the following cells we'll extract these embeddings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6db22a69",
+   "metadata": {
+    "id": "6db22a69"
+   },
+   "outputs": [],
+   "source": [
+    "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+    "print(f'Device to be used: {device}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94ecb2a6",
+   "metadata": {
+    "id": "94ecb2a6"
+   },
+   "source": [
+    "Let us load the pre-trained model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94f288a2",
+   "metadata": {
+    "id": "94f288a2"
+   },
+   "outputs": [],
+   "source": [
+    "MODEL_URL='https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/models/resnet18_cifar10_epoch5.pth'\n",
+    "MODEL_PATH='resnet18_cifar10_epoch5.pth'\n",
+    "\n",
+    "def load_model(device):\n",
+    "    \"\"\"Loads the pre-trained CIFAR-10 model\"\"\"\n",
+    "    model = resnet18()\n",
+    "    model.fc = nn.Sequential(\n",
+    "        nn.Linear(512, 128),\n",
+    "        nn.ReLU(),\n",
+    "        nn.Linear(128, 10),\n",
+    "    )\n",
+    "\n",
+    "    r = requests.get(MODEL_URL)\n",
+    "    with open(MODEL_PATH,'wb') as f:\n",
+    "        f.write(r.content)\n",
+    "\n",
+    "    model.load_state_dict(torch.load(MODEL_PATH, map_location=torch.device(device)))\n",
+    "    model.to(device)\n",
+    "    return model\n",
+    "\n",
+    "resnet_model = load_model(device)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ad83d0d",
+   "metadata": {
+    "id": "1ad83d0d"
+   },
+   "source": [
+    "We'll load four tranches of [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) data for this example.  \"reference\" – corresponding to train-time reference data, and three \"production\" sets with diffrent transformations applied to simulate drift from the model's training data. Note that running the cell below will download the CIFAR-10 data and load them using torch's dataloaders."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "BIaNR9dKW85v",
+   "metadata": {
+    "id": "BIaNR9dKW85v"
+   },
+   "outputs": [],
+   "source": [
+    "BATCH_SIZE = 32\n",
+    "\n",
+    "transform = transforms.Compose([\n",
+    "        transforms.ToTensor(),\n",
+    "        transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),\n",
+    "    ])\n",
+    "\n",
+    "DATA_BASE_URL = 'https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/data/cv_monitoring/'\n",
+    "\n",
+    "# download file from URL\n",
+    "DATA_URLS = {\n",
+    " 'reference' : DATA_BASE_URL + 'reference/image_data.npz',\n",
+    "'production_1': DATA_BASE_URL + 'production_1/image_data.npz', # Undrifted\n",
+    "'production_2': DATA_BASE_URL + 'production_2/image_data.npz', # Blurred\n",
+    "'production_3': DATA_BASE_URL + 'production_3/image_data.npz'} # Darkened\n",
+    "\n",
+    "\n",
+    "def get_dataloader(dataset):\n",
+    "  response = requests.get(DATA_URLS[dataset])\n",
+    "  data = np.load(io.BytesIO(response.content))\n",
+    "\n",
+    "  images = [transform(x) for x in data['arr_0']]\n",
+    "  labels = data['arr_1']\n",
+    "\n",
+    "  tuple_list = list(zip(images, labels))\n",
+    "\n",
+    "  return torch.utils.data.DataLoader(\n",
+    "      tuple_list,\n",
+    "      batch_size=BATCH_SIZE,\n",
+    "      shuffle=False,\n",
+    "      num_workers=2\n",
+    "  )\n",
+    "\n",
+    "# let's test it\n",
+    "get_dataloader('reference')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6effa9e",
+   "metadata": {
+    "id": "f6effa9e"
+   },
+   "source": [
+    "***In the cell below we define functions that will extract the 128-dimensional embedding from the FC1 layer of the model and package them in a dataframe along with predictions, ground-truth labels, and image URLs***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9077f38f",
+   "metadata": {
+    "id": "9077f38f"
+   },
+   "outputs": [],
+   "source": [
+    "from copy import deepcopy\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn.functional as F\n",
+    "import torchvision.transforms as transforms\n",
+    "\n",
+    "torch.manual_seed(0)\n",
+    "\n",
+    "CIFAR_CLASSES = (\n",
+    "    'plane', 'car', 'bird', 'cat',\n",
+    "    'deer', 'dog', 'frog',\n",
+    "    'horse', 'ship', 'truck',\n",
+    ")\n",
+    "\n",
+    "global view_fc1_output_embeds\n",
+    "\n",
+    "def fc1_hook_func(model, input, output):\n",
+    "    global view_fc1_output_embeds\n",
+    "    view_fc1_output_embeds = output\n",
+    "\n",
+    "def idx_to_classes(target_arr):\n",
+    "    return [CIFAR_CLASSES[int(i)] for i in target_arr]\n",
+    "\n",
+    "def generate_embeddings(model, device, dataset_name):\n",
+    "    \"\"\"Generate embeddings for the inout images\"\"\"\n",
+    "\n",
+    "    dataloader = get_dataloader(dataset_name)\n",
+    "\n",
+    "    fc1_embeds = []\n",
+    "    output_scores = []\n",
+    "    target = []\n",
+    "\n",
+    "    with torch.no_grad():\n",
+    "        model = model.eval()\n",
+    "        fc1_module = model.fc[0]\n",
+    "        fc1_hook = fc1_module.register_forward_hook(fc1_hook_func)\n",
+    "        correct_preds = 0\n",
+    "        total_preds = 0\n",
+    "\n",
+    "        try:\n",
+    "            for inputs, labels in dataloader:\n",
+    "                inputs = inputs.to(device)\n",
+    "                labels = labels.to(device)\n",
+    "                outputs = model(inputs)\n",
+    "                outputs_smax = F.softmax(outputs, dim=1)\n",
+    "                _, preds = torch.max(outputs, 1)\n",
+    "                correct_preds += torch.sum(preds == labels.data).cpu().numpy()\n",
+    "                total_preds += len(inputs)\n",
+    "\n",
+    "                fc1_embeds.append(view_fc1_output_embeds.cpu().detach().numpy())\n",
+    "                output_scores.append(outputs_smax.cpu().detach().numpy())\n",
+    "                target.append(labels.cpu().detach().numpy())\n",
+    "\n",
+    "            fc1_embeds = np.concatenate(fc1_embeds)\n",
+    "            output_scores = np.concatenate(output_scores)\n",
+    "            target = np.concatenate(target)\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            fc1_hook.remove()\n",
+    "            raise\n",
+    "\n",
+    "        print(f'{correct_preds}/{total_preds}: {100*correct_preds/total_preds:5.1f}% correct predictions.')\n",
+    "\n",
+    "    embs = deepcopy(fc1_embeds)\n",
+    "    labels = idx_to_classes(target)\n",
+    "    embedding_cols = ['emb_'+str(i) for i in range(128)]\n",
+    "    baseline_embeddings = pd.DataFrame(embs, columns=embedding_cols)\n",
+    "\n",
+    "    columns_to_combine = baseline_embeddings.columns\n",
+    "    baseline_embeddings = baseline_embeddings.apply(lambda row: row[columns_to_combine].tolist(), axis=1).to_frame()\n",
+    "    baseline_embeddings = baseline_embeddings.rename(columns={baseline_embeddings.columns[0]: 'embeddings'})\n",
+    "\n",
+    "    baseline_predictions = pd.DataFrame(output_scores, columns=CIFAR_CLASSES)\n",
+    "    baseline_labels = pd.DataFrame(labels, columns=['target'])\n",
+    "    embeddings_df = pd.concat(\n",
+    "        [baseline_embeddings, baseline_predictions, baseline_labels],\n",
+    "        axis='columns',\n",
+    "        ignore_index=False\n",
+    "    )\n",
+    "\n",
+    "    embeddings_df['image_url'] = embeddings_df.apply(lambda row:DATA_BASE_URL + dataset_name + '/' + str(row.name) + '.png', axis=1)\n",
+    "\n",
+    "\n",
+    "    return embeddings_df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56726d41",
+   "metadata": {
+    "id": "56726d41"
+   },
+   "source": [
+    "We'll now extract the embeddings for training data which will serve as baseline for monitoring."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "WXwRTqVPgJ10",
+   "metadata": {
+    "id": "WXwRTqVPgJ10"
+   },
+   "outputs": [],
+   "source": [
+    "sample_df = generate_embeddings(resnet_model, device, 'reference')\n",
+    "sample_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47edf8eb",
+   "metadata": {
+    "id": "47edf8eb"
+   },
+   "source": [
+    "# 4. Add metadata about the model\n",
+    "\n",
+    "Next we must tell Fiddler a bit more about our model.  This is done by by creating defining some information about our model's task, inputs, output, target and which features form the image embedding and then creating a `Model` object.\n",
+    "\n",
+    "Let's first define our Image vector using the API below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "205af1a0",
+   "metadata": {
+    "id": "205af1a0"
+   },
+   "outputs": [],
+   "source": [
+    "image_embedding_feature = fdl.ImageEmbedding(\n",
+    "    name='image_feature',\n",
+    "    source_column='image_url',\n",
+    "    column='embeddings',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a57898d3",
+   "metadata": {
+    "id": "a57898d3"
+   },
+   "source": [
+    "Now let's define a `ModelSpec` object with information about the columns in our data sample."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4dd70f23-49f2-46a9-96a4-fb3ae341e892",
+   "metadata": {
+    "id": "4dd70f23-49f2-46a9-96a4-fb3ae341e892"
+   },
+   "outputs": [],
+   "source": [
+    "model_spec = fdl.ModelSpec(\n",
+    "    inputs=['embeddings'],\n",
+    "    outputs=CIFAR_CLASSES,\n",
+    "    targets=['target'],\n",
+    "    metadata=['image_url'],\n",
+    "    custom_features=[image_embedding_feature],\n",
+    ")\n",
+    "\n",
+    "timestamp_column = 'timestamp'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "162fcae1-1ad9-4a88-9f20-d13070d45389",
+   "metadata": {
+    "id": "162fcae1-1ad9-4a88-9f20-d13070d45389"
+   },
+   "source": [
+    "Then let's specify some information about the model task."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5050744-1528-4ba3-954e-1a6306a8d44e",
+   "metadata": {
+    "id": "c5050744-1528-4ba3-954e-1a6306a8d44e"
+   },
+   "outputs": [],
+   "source": [
+    "model_task = fdl.ModelTask.MULTICLASS_CLASSIFICATION\n",
+    "\n",
+    "task_params = fdl.ModelTaskParams(target_class_order=list(CIFAR_CLASSES))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a7110b2",
+   "metadata": {
+    "id": "6a7110b2"
+   },
+   "source": [
+    "Then we create a `Model` schema using the example data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43e75271",
+   "metadata": {
+    "id": "43e75271"
+   },
+   "outputs": [],
+   "source": [
+    "MODEL_NAME = 'resnet18'\n",
+    "\n",
+    "model = fdl.Model.from_data(\n",
+    "    name=MODEL_NAME,\n",
+    "    project_id=fdl.Project.from_name(PROJECT_NAME).id,\n",
+    "    source=sample_df,\n",
+    "    spec=model_spec,\n",
+    "    task=model_task,\n",
+    "    task_params=task_params,\n",
+    "    event_ts_col=timestamp_column\n",
+    ")\n",
+    "\n",
+    "model.create()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "xoAJEkK-iXwY",
+   "metadata": {
+    "id": "xoAJEkK-iXwY"
+   },
+   "source": [
+    "Additionally, let's publish the baseline data so we can use it as a reference for measuring drift and to compare production data with in Embedding Visualization for root-cause analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cian7DBwuU4B",
+   "metadata": {
+    "id": "cian7DBwuU4B"
+   },
+   "outputs": [],
+   "source": [
+    "model.publish(\n",
+    "    source=sample_df,\n",
+    "    environment=fdl.EnvType.PRE_PRODUCTION,\n",
+    "    dataset_name='train_time_reference',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cff619a6",
+   "metadata": {
+    "id": "cff619a6"
+   },
+   "source": [
+    "# 5. Publish events to Fiddler\n",
+    "We'll publish events over past 3 weeks.\n",
+    "\n",
+    "- Week 1: We publish CIFAR-10 test set, which would signify no distributional shift\n",
+    "- Week 2: We publish **blurred** CIFAR-10 test set\n",
+    "- Week 3: We publish **brightness reduced** CIFAR-10 test set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db89da28",
+   "metadata": {
+    "id": "db89da28"
+   },
+   "outputs": [],
+   "source": [
+    "for i, dataset_name in enumerate(['production_1', 'production_2', 'production_3']):\n",
+    "    week_days = 6\n",
+    "    prod_df = generate_embeddings(resnet_model, device, dataset_name)\n",
+    "    week_offset = (2-i)*7*24*60*60*1e3\n",
+    "    day_offset = 24*60*60*1e3\n",
+    "    print(f'Publishing events from {dataset_name} transformation for week {i+1}.')\n",
+    "    for day in range(week_days):\n",
+    "        now = time.time() * 1000\n",
+    "        timestamp = int(now - week_offset - day*day_offset)\n",
+    "        events_df = prod_df.sample(1000)\n",
+    "        events_df['timestamp'] = timestamp\n",
+    "        model.publish(events_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb57a1fd",
+   "metadata": {
+    "id": "eb57a1fd"
+   },
+   "source": [
+    "## 6. Get insights\n",
+    "\n",
+    "**You're all done!**\n",
+    "  \n",
+    "You can now head to your Fiddler URL and start getting enhanced observability into your model's performance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45cebc85",
+   "metadata": {
+    "id": "45cebc85"
+   },
+   "source": [
+    "Fiddler can now track your image drift over time based on the embedding vectors of the images published into the platform.\n",
+    "\n",
+    "While we saw performace degrade for the various drifted data sets in the notebook when publishing (which can also be plotted in the Monitoring chart), embedding drift doesn't require ground-truth labels and often serves as a useful proxy that can indicate a problem or degraded performance.  Data drift is indicated by nonzero Jensen-Shannon Distance measured with respect to a reference sample.\n",
+    "\n",
+    "Please visit your Fiddler environment upon completion to check this out for yourself."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9dd52c2-8df7-427a-aa65-cde58eb07e43",
+   "metadata": {
+    "id": "c9dd52c2-8df7-427a-aa65-cde58eb07e43"
+   },
+   "source": [
+    "<table>\n",
+    "    <tr>\n",
+    "        <td>\n",
+    "            <img src=\"https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/images/image_monitoring_2024_12_1.png\" />\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dLHr8Au8fhnh",
+   "metadata": {
+    "id": "dLHr8Au8fhnh"
+   },
+   "source": [
+    "In order to identify the root cause of data drift, Fiddler allows you to \"drill-down\" into time windows where embedding drift is measured.  As indicated in blue in the image above, by selecting a time bin and clicking the \"Embeddings\" button, you'll be take to an Embedding Visualization chart where data from that time window is compared against reference data (e.g. `train_time_reference` that we published above) in an interactive 3D UMAP plot.\n",
+    "\n",
+    "In the image below, the embedded images in the drifted time period are semantically distinct to your model from those in the train-time sample.  By investigating these differenes, it's easy to determine that the third \"production\" sample is systematically darkened."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "iVp03aS9fUXL",
+   "metadata": {
+    "id": "iVp03aS9fUXL"
+   },
+   "source": [
+    "<table>\n",
+    "    <tr>\n",
+    "        <td>\n",
+    "            <img src=\"https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/images/image_monitoring_2024_12_2.png\" />\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "800aecc2",
+   "metadata": {
+    "id": "800aecc2"
+   },
+   "source": [
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n",
+    "**Questions?**  \n",
+    "  \n",
+    "Check out [our docs](https://docs.fiddler.ai/) for a more detailed explanation of what Fiddler has to offer.\n",
+    "\n",
+    "Join our [community Slack](http://fiddler-community.slack.com/) to ask any questions!\n",
+    "\n",
+    "If you're still looking for answers, fill out a ticket on [our support page](https://fiddlerlabs.zendesk.com/) and we'll get back to you shortly."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "L4",
+   "machine_shape": "hm",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/quickstart/latest/Fiddler_Quickstart_Image_Monitoring.ipynb
+++ b/quickstart/latest/Fiddler_Quickstart_Image_Monitoring.ipynb
@@ -1,741 +1,723 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "18a75022",
-   "metadata": {
-    "id": "18a75022"
-   },
-   "source": [
-    "# Monitoring Image data using Fiddler Vector Monitoring\n",
-    "\n",
-    "In this notebook we present the steps for monitoring images. Fiddler employs a vector-based monitoring approach that can be used to monitor data drift in high-dimensional data such as NLP embeddings, images, video etc. In this notebook we demonstrate how to detect drift in image data using model embeddings.\n",
-    "\n",
-    "Fiddler is the pioneer in enterprise Model Performance Management (MPM), offering a unified platform that enables Data Science, MLOps, Risk, Compliance, Analytics, and LOB teams to **monitor, explain, analyze, and improve ML deployments at enterprise scale**.\n",
-    "Obtain contextual insights at any stage of the ML lifecycle, improve predictions, increase transparency and fairness, and optimize business revenue.\n",
-    "\n",
-    "---\n",
-    "\n",
-    "You can experience Fiddler's Image monitoring ***in minutes*** by following these quick steps:\n",
-    "\n",
-    "1. Connect to Fiddler\n",
-    "2. Load and generate embeddings for CIFAR-10 dataset\n",
-    "3. Upload the vectorized baseline dataset\n",
-    "4. Add metadata about your model\n",
-    "5. Inject data drift and publish production events\n",
-    "6. Get insights"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "18a75022",
+      "metadata": {
+        "id": "18a75022"
+      },
+      "source": [
+        "# Monitoring Image data using Fiddler Vector Monitoring\n",
+        "\n",
+        "In this notebook we present the steps for monitoring images. Fiddler employs a vector-based monitoring approach that can be used to monitor data drift in high-dimensional data such as NLP embeddings, images, video etc. In this notebook we demonstrate how to detect drift in image data using model embeddings and determine the cause of that drift.\n",
+        "\n",
+        "Fiddler is the pioneer in enterprise Model Performance Management (MPM), offering a unified platform that enables Data Science, MLOps, Risk, Compliance, Analytics, and LOB teams to **monitor, explain, analyze, and improve ML deployments at enterprise scale**.\n",
+        "Obtain contextual insights at any stage of the ML lifecycle, improve predictions, increase transparency and fairness, and optimize business revenue.\n",
+        "\n",
+        "---\n",
+        "\n",
+        "You can experience Fiddler's Image monitoring ***in minutes*** by following these quick steps:\n",
+        "\n",
+        "1. Connect to Fiddler\n",
+        "2. Load and generate embeddings for CIFAR-10 dataset\n",
+        "3. Upload the vectorized baseline dataset\n",
+        "4. Add metadata about your model\n",
+        "5. Inject data drift and publish production events\n",
+        "6. Get insights"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "443126a9",
+      "metadata": {
+        "id": "443126a9"
+      },
+      "source": [
+        "## Imports"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "749423fa",
+      "metadata": {
+        "id": "749423fa"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install torch==2.0.0\n",
+        "!pip install torchvision==0.15.1\n",
+        "!pip install -q fiddler-client"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ce568ccb",
+      "metadata": {
+        "id": "ce568ccb"
+      },
+      "outputs": [],
+      "source": [
+        "import io\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import random\n",
+        "import time\n",
+        "import torch\n",
+        "import torch.nn as nn\n",
+        "import torchvision.transforms as transforms\n",
+        "from torchvision.models import resnet18, ResNet18_Weights\n",
+        "import requests\n",
+        "\n",
+        "import fiddler as fdl\n",
+        "print(f\"Running Fiddler client version {fdl.__version__}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "e2dead36",
+      "metadata": {
+        "id": "e2dead36"
+      },
+      "source": [
+        "## 2. Connect to Fiddler\n",
+        "\n",
+        "Before you can add information about your model with Fiddler, you'll need to connect using our API client.\n",
+        "\n",
+        "\n",
+        "---\n",
+        "\n",
+        "\n",
+        "**We need a few pieces of information to get started.**\n",
+        "1. The URL you're using to connect to Fiddler\n",
+        "2. Your authorization token\n",
+        "\n",
+        "These can be found by navigating to the **Settings** page of your Fiddler environment."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a41e2e8d",
+      "metadata": {
+        "id": "a41e2e8d"
+      },
+      "outputs": [],
+      "source": [
+        "URL = ''  # Make sure to include the full URL (including https://).\n",
+        "TOKEN = ''"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "024b0fda",
+      "metadata": {
+        "id": "024b0fda"
+      },
+      "source": [
+        "Now just run the following code block to connect to the Fiddler API!"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "627e583c",
+      "metadata": {
+        "id": "627e583c"
+      },
+      "outputs": [],
+      "source": [
+        "fdl.init(\n",
+        "    url=URL,\n",
+        "    token=TOKEN\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "3c513f82",
+      "metadata": {
+        "id": "3c513f82"
+      },
+      "source": [
+        "Once you connect, you can create a new project by calling a Project's `create` method."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b3db485e",
+      "metadata": {
+        "id": "b3db485e"
+      },
+      "outputs": [],
+      "source": [
+        "PROJECT_NAME = 'image_monitoring'\n",
+        "\n",
+        "project = fdl.Project(\n",
+        "    name=PROJECT_NAME\n",
+        ")\n",
+        "\n",
+        "project.create()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "19011830",
+      "metadata": {
+        "id": "19011830"
+      },
+      "source": [
+        "## 2. Generate Embeddings for CIFAR-10 data\n",
+        "\n",
+        "In this example, we'll use the popular CIFAR-10 classification dataset and a model based on Resnet-18 architecture. For the purpose of this example we have pre-trained the model.\n",
+        "  \n",
+        "In order to compute data and prediction drift, **Fiddler needs a sample of data that can serve as a baseline** for making comparisons with data in production. When it comes to computing distributional shift for images, Fiddler relies on the model's intermediate representations also known as activations or embeddings. You can read more about our approach [here](https://www.fiddler.ai/blog/monitoring-natural-language-processing-and-computer-vision-models-part-1).\n",
+        "\n",
+        "In the the following cells we'll extract these embeddings."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "6db22a69",
+      "metadata": {
+        "id": "6db22a69"
+      },
+      "outputs": [],
+      "source": [
+        "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+        "print(f'Device to be used: {device}')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "94ecb2a6",
+      "metadata": {
+        "id": "94ecb2a6"
+      },
+      "source": [
+        "Let us load the pre-trained model"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "94f288a2",
+      "metadata": {
+        "id": "94f288a2"
+      },
+      "outputs": [],
+      "source": [
+        "MODEL_URL='https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/models/resnet18_cifar10_epoch5.pth'\n",
+        "MODEL_PATH='resnet18_cifar10_epoch5.pth'\n",
+        "\n",
+        "def load_model(device):\n",
+        "    \"\"\"Loads the pre-trained CIFAR-10 model\"\"\"\n",
+        "    model = resnet18()\n",
+        "    model.fc = nn.Sequential(\n",
+        "        nn.Linear(512, 128),\n",
+        "        nn.ReLU(),\n",
+        "        nn.Linear(128, 10),\n",
+        "    )\n",
+        "\n",
+        "    r = requests.get(MODEL_URL)\n",
+        "    with open(MODEL_PATH,'wb') as f:\n",
+        "        f.write(r.content)\n",
+        "\n",
+        "    model.load_state_dict(torch.load(MODEL_PATH, map_location=torch.device(device)))\n",
+        "    model.to(device)\n",
+        "    return model\n",
+        "\n",
+        "resnet_model = load_model(device)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "1ad83d0d",
+      "metadata": {
+        "id": "1ad83d0d"
+      },
+      "source": [
+        "We'll load four tranches of [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html) data for this example.  \"reference\" – corresponding to train-time reference data, and three \"production\" sets with diffrent transformations applied to simulate drift from the model's training data. Note that running the cell below will download the CIFAR-10 data and load them using torch's dataloaders."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "BATCH_SIZE = 32\n",
+        "\n",
+        "transform = transforms.Compose([\n",
+        "        transforms.ToTensor(),\n",
+        "        transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),\n",
+        "    ])\n",
+        "\n",
+        "DATA_BASE_URL = 'https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/data/cv_monitoring/'\n",
+        "\n",
+        "# download file from URL\n",
+        "DATA_URLS = {\n",
+        " 'reference' : DATA_BASE_URL + 'reference/image_data.npz',\n",
+        "'production_1': DATA_BASE_URL + 'production_1/image_data.npz', # Undrifted\n",
+        "'production_2': DATA_BASE_URL + 'production_2/image_data.npz', # Blurred\n",
+        "'production_3': DATA_BASE_URL + 'production_3/image_data.npz'} # Darkened\n",
+        "\n",
+        "\n",
+        "def get_dataloader(dataset):\n",
+        "  response = requests.get(DATA_URLS[dataset])\n",
+        "  data = np.load(io.BytesIO(response.content))\n",
+        "\n",
+        "  images = [transform(x) for x in data['arr_0']]\n",
+        "  labels = data['arr_1']\n",
+        "\n",
+        "  tuple_list = list(zip(images, labels))\n",
+        "\n",
+        "  return torch.utils.data.DataLoader(\n",
+        "      tuple_list,\n",
+        "      batch_size=BATCH_SIZE,\n",
+        "      shuffle=False,\n",
+        "      num_workers=2\n",
+        "  )\n",
+        "\n",
+        "get_dataloader('reference')"
+      ],
+      "metadata": {
+        "id": "BIaNR9dKW85v"
+      },
+      "id": "BIaNR9dKW85v",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f6effa9e",
+      "metadata": {
+        "id": "f6effa9e"
+      },
+      "source": [
+        "***In the cell below we define functions that will extract the 128-dimensional embedding from the FC1 layer of the model and package them in a dataframe along with predictions, ground-truth labels, and image URLs***"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "9077f38f",
+      "metadata": {
+        "id": "9077f38f"
+      },
+      "outputs": [],
+      "source": [
+        "from copy import deepcopy\n",
+        "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
+        "\n",
+        "import torch\n",
+        "import torch.nn.functional as F\n",
+        "import torchvision.transforms as transforms\n",
+        "\n",
+        "torch.manual_seed(0)\n",
+        "\n",
+        "CIFAR_CLASSES = (\n",
+        "    'plane', 'car', 'bird', 'cat',\n",
+        "    'deer', 'dog', 'frog',\n",
+        "    'horse', 'ship', 'truck',\n",
+        ")\n",
+        "\n",
+        "global view_fc1_output_embeds\n",
+        "\n",
+        "def fc1_hook_func(model, input, output):\n",
+        "    global view_fc1_output_embeds\n",
+        "    view_fc1_output_embeds = output\n",
+        "\n",
+        "def idx_to_classes(target_arr):\n",
+        "    return [CIFAR_CLASSES[int(i)] for i in target_arr]\n",
+        "\n",
+        "def generate_embeddings(model, device, dataset_name):\n",
+        "    \"\"\"Generate embeddings for the inout images\"\"\"\n",
+        "\n",
+        "    dataloader = get_dataloader(dataset_name)\n",
+        "\n",
+        "    fc1_embeds = []\n",
+        "    output_scores = []\n",
+        "    target = []\n",
+        "\n",
+        "    with torch.no_grad():\n",
+        "        model = model.eval()\n",
+        "        fc1_module = model.fc[0]\n",
+        "        fc1_hook = fc1_module.register_forward_hook(fc1_hook_func)\n",
+        "        correct_preds = 0\n",
+        "        total_preds = 0\n",
+        "\n",
+        "        try:\n",
+        "            for inputs, labels in dataloader:\n",
+        "                inputs = inputs.to(device)\n",
+        "                labels = labels.to(device)\n",
+        "                outputs = model(inputs)\n",
+        "                outputs_smax = F.softmax(outputs, dim=1)\n",
+        "                _, preds = torch.max(outputs, 1)\n",
+        "                correct_preds += torch.sum(preds == labels.data).cpu().numpy()\n",
+        "                total_preds += len(inputs)\n",
+        "\n",
+        "                fc1_embeds.append(view_fc1_output_embeds.cpu().detach().numpy())\n",
+        "                output_scores.append(outputs_smax.cpu().detach().numpy())\n",
+        "                target.append(labels.cpu().detach().numpy())\n",
+        "\n",
+        "            fc1_embeds = np.concatenate(fc1_embeds)\n",
+        "            output_scores = np.concatenate(output_scores)\n",
+        "            target = np.concatenate(target)\n",
+        "\n",
+        "        except Exception as e:\n",
+        "            fc1_hook.remove()\n",
+        "            raise\n",
+        "\n",
+        "        print(f'{correct_preds}/{total_preds}: {100*correct_preds/total_preds:5.1f}% correct predictions.')\n",
+        "\n",
+        "    embs = deepcopy(fc1_embeds)\n",
+        "    labels = idx_to_classes(target)\n",
+        "    embedding_cols = ['emb_'+str(i) for i in range(128)]\n",
+        "    baseline_embeddings = pd.DataFrame(embs, columns=embedding_cols)\n",
+        "\n",
+        "    columns_to_combine = baseline_embeddings.columns\n",
+        "    baseline_embeddings = baseline_embeddings.apply(lambda row: row[columns_to_combine].tolist(), axis=1).to_frame()\n",
+        "    baseline_embeddings = baseline_embeddings.rename(columns={baseline_embeddings.columns[0]: 'embeddings'})\n",
+        "\n",
+        "    baseline_predictions = pd.DataFrame(output_scores, columns=CIFAR_CLASSES)\n",
+        "    baseline_labels = pd.DataFrame(labels, columns=['target'])\n",
+        "    embeddings_df = pd.concat(\n",
+        "        [baseline_embeddings, baseline_predictions, baseline_labels],\n",
+        "        axis='columns',\n",
+        "        ignore_index=False\n",
+        "    )\n",
+        "\n",
+        "    embeddings_df['image_url'] = embeddings_df.apply(lambda row:DATA_BASE_URL + dataset_name + '/' + str(row.name) + '.png', axis=1)\n",
+        "\n",
+        "\n",
+        "    return embeddings_df\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "56726d41",
+      "metadata": {
+        "id": "56726d41"
+      },
+      "source": [
+        "We'll now extract the embeddings for training data which will serve as baseline for monitoring."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "sample_df = generate_embeddings(resnet_model, device, 'reference')\n",
+        "sample_df.head()"
+      ],
+      "metadata": {
+        "id": "WXwRTqVPgJ10"
+      },
+      "id": "WXwRTqVPgJ10",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "id": "47edf8eb",
+      "metadata": {
+        "id": "47edf8eb"
+      },
+      "source": [
+        "# 4. Add metadata about the model\n",
+        "\n",
+        "Next we must tell Fiddler a bit more about our model.  This is done by by creating defining some information about our model's task, inputs, output, target and which features form the image embedding and then creating a `Model` object.\n",
+        "\n",
+        "Let's first define our Image vector using the API below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "205af1a0",
+      "metadata": {
+        "id": "205af1a0"
+      },
+      "outputs": [],
+      "source": [
+        "image_embedding_feature = fdl.ImageEmbedding(\n",
+        "    name='image_feature',\n",
+        "    source_column='image_url',\n",
+        "    column='embeddings',\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a57898d3",
+      "metadata": {
+        "id": "a57898d3"
+      },
+      "source": [
+        "Now let's define a `ModelSpec` object with information about the columns in our data sample."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "4dd70f23-49f2-46a9-96a4-fb3ae341e892",
+      "metadata": {
+        "id": "4dd70f23-49f2-46a9-96a4-fb3ae341e892"
+      },
+      "outputs": [],
+      "source": [
+        "model_spec = fdl.ModelSpec(\n",
+        "    inputs=['embeddings'],\n",
+        "    outputs=CIFAR_CLASSES,\n",
+        "    targets=['target'],\n",
+        "    metadata=['image_url'],\n",
+        "    custom_features=[image_embedding_feature],\n",
+        ")\n",
+        "\n",
+        "timestamp_column = 'timestamp'"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "162fcae1-1ad9-4a88-9f20-d13070d45389",
+      "metadata": {
+        "id": "162fcae1-1ad9-4a88-9f20-d13070d45389"
+      },
+      "source": [
+        "Then let's specify some information about the model task."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c5050744-1528-4ba3-954e-1a6306a8d44e",
+      "metadata": {
+        "id": "c5050744-1528-4ba3-954e-1a6306a8d44e"
+      },
+      "outputs": [],
+      "source": [
+        "model_task = fdl.ModelTask.MULTICLASS_CLASSIFICATION\n",
+        "\n",
+        "task_params = fdl.ModelTaskParams(target_class_order=list(CIFAR_CLASSES))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "6a7110b2",
+      "metadata": {
+        "id": "6a7110b2"
+      },
+      "source": [
+        "Then we create a `Model` schema using the example data."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "43e75271",
+      "metadata": {
+        "id": "43e75271"
+      },
+      "outputs": [],
+      "source": [
+        "MODEL_NAME = 'resnet18'\n",
+        "\n",
+        "model = fdl.Model.from_data(\n",
+        "    name=MODEL_NAME,\n",
+        "    project_id=fdl.Project.from_name(PROJECT_NAME).id,\n",
+        "    source=sample_df,\n",
+        "    spec=model_spec,\n",
+        "    task=model_task,\n",
+        "    task_params=task_params,\n",
+        "    event_ts_col=timestamp_column\n",
+        ")\n",
+        "\n",
+        "model.create()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Additionally, let's publish the baseline data so we can use it as a reference for measuring drift and to compare production data with in Embedding Visualization for root-cause analysis."
+      ],
+      "metadata": {
+        "id": "xoAJEkK-iXwY"
+      },
+      "id": "xoAJEkK-iXwY"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "model.publish(\n",
+        "    source=sample_df,\n",
+        "    environment=fdl.EnvType.PRE_PRODUCTION,\n",
+        "    dataset_name='train_time_reference',\n",
+        ")"
+      ],
+      "metadata": {
+        "id": "cian7DBwuU4B"
+      },
+      "id": "cian7DBwuU4B",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "id": "cff619a6",
+      "metadata": {
+        "id": "cff619a6"
+      },
+      "source": [
+        "# 5. Publish events to Fiddler\n",
+        "We'll publish events over past 3 weeks.\n",
+        "\n",
+        "- Week 1: We publish CIFAR-10 test set, which would signify no distributional shift\n",
+        "- Week 2: We publish **blurred** CIFAR-10 test set\n",
+        "- Week 3: We publish **brightness reduced** CIFAR-10 test set"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "db89da28",
+      "metadata": {
+        "id": "db89da28"
+      },
+      "outputs": [],
+      "source": [
+        "for i, dataset_name in enumerate(['production_1', 'production_2', 'production_3']):\n",
+        "    week_days = 6\n",
+        "    prod_df = generate_embeddings(resnet_model, device, dataset_name)\n",
+        "    week_offset = (2-i)*7*24*60*60*1e3\n",
+        "    day_offset = 24*60*60*1e3\n",
+        "    print(f'Publishing events from {dataset_name} transformation for week {i+1}.')\n",
+        "    for day in range(week_days):\n",
+        "        now = time.time() * 1000\n",
+        "        timestamp = int(now - week_offset - day*day_offset)\n",
+        "        events_df = prod_df.sample(1000)\n",
+        "        events_df['timestamp'] = timestamp\n",
+        "        model.publish(events_df)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "eb57a1fd",
+      "metadata": {
+        "id": "eb57a1fd"
+      },
+      "source": [
+        "## 6. Get insights\n",
+        "\n",
+        "**You're all done!**\n",
+        "  \n",
+        "You can now head to your Fiddler URL and start getting enhanced observability into your model's performance."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "45cebc85",
+      "metadata": {
+        "id": "45cebc85"
+      },
+      "source": [
+        "Fiddler can now track your image drift over time based on the embedding vectors of the images published into the platform.\n",
+        "\n",
+        "While we saw performace degrade for the various drifted data sets (this can also be plotted in tehe Monitoring chart), embedding drift doesn't require ground-truth labels as with performance metrics and often serves as a useful proxy that can indicate a problem or degraded performance.\n",
+        "\n",
+        "Please visit your Fiddler environment upon completion to check this out for yourself."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "c9dd52c2-8df7-427a-aa65-cde58eb07e43",
+      "metadata": {
+        "id": "c9dd52c2-8df7-427a-aa65-cde58eb07e43"
+      },
+      "source": [
+        "<table>\n",
+        "    <tr>\n",
+        "        <td>\n",
+        "            <img src=\"https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/images/image_monitoring_2024_12_1.png\" />\n",
+        "        </td>\n",
+        "    </tr>\n",
+        "</table>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "In order to identify the root cause of data drift, Fiddler allows you to \"drill-down\" into time windows where embedding drift has been identified.  As indicated in blue in the image above, by selecting a time bin and clicking the \"Embeddings\" button, you'll be take to an Embedding Visualization chart where data from that time window is compared against reference data (e.g. `train_time_reference` that we published above) in an interactive 3D UMAP plot.\n",
+        "\n",
+        "In the image below, the embedded images in the drifted time period are semantically distinct to your model from the train-time sample.  By investigating these differents, it's easy to determine that the third \"production\" sample is darkened."
+      ],
+      "metadata": {
+        "id": "dLHr8Au8fhnh"
+      },
+      "id": "dLHr8Au8fhnh"
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "<table>\n",
+        "    <tr>\n",
+        "        <td>\n",
+        "            <img src=\"https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/images/image_monitoring_2024_12_2.png\" />\n",
+        "        </td>\n",
+        "    </tr>\n",
+        "</table>"
+      ],
+      "metadata": {
+        "id": "iVp03aS9fUXL"
+      },
+      "id": "iVp03aS9fUXL"
+    },
+    {
+      "cell_type": "markdown",
+      "id": "800aecc2",
+      "metadata": {
+        "id": "800aecc2"
+      },
+      "source": [
+        "\n",
+        "\n",
+        "---\n",
+        "\n",
+        "\n",
+        "**Questions?**  \n",
+        "  \n",
+        "Check out [our docs](https://docs.fiddler.ai/) for a more detailed explanation of what Fiddler has to offer.\n",
+        "\n",
+        "Join our [community Slack](http://fiddler-community.slack.com/) to ask any questions!\n",
+        "\n",
+        "If you're still looking for answers, fill out a ticket on [our support page](https://fiddlerlabs.zendesk.com/) and we'll get back to you shortly."
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "machine_shape": "hm",
+      "gpuType": "L4"
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.3"
+    },
+    "accelerator": "GPU"
   },
-  {
-   "cell_type": "markdown",
-   "id": "443126a9",
-   "metadata": {
-    "id": "443126a9"
-   },
-   "source": [
-    "## Imports"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "749423fa",
-   "metadata": {
-    "id": "749423fa"
-   },
-   "outputs": [],
-   "source": [
-    "!pip install torch==2.0.0\n",
-    "!pip install torchvision==0.15.1\n",
-    "!pip install -q fiddler-client"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ce568ccb",
-   "metadata": {
-    "id": "ce568ccb"
-   },
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import random\n",
-    "import time\n",
-    "import torch\n",
-    "import torch.nn as nn\n",
-    "import torchvision.transforms as transforms\n",
-    "from torchvision.models import resnet18, ResNet18_Weights\n",
-    "import torchvision\n",
-    "import requests\n",
-    "\n",
-    "import fiddler as fdl\n",
-    "print(f\"Running Fiddler client version {fdl.__version__}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e2dead36",
-   "metadata": {
-    "id": "e2dead36"
-   },
-   "source": [
-    "## 2. Connect to Fiddler\n",
-    "\n",
-    "Before you can add information about your model with Fiddler, you'll need to connect using our API client.\n",
-    "\n",
-    "\n",
-    "---\n",
-    "\n",
-    "\n",
-    "**We need a few pieces of information to get started.**\n",
-    "1. The URL you're using to connect to Fiddler\n",
-    "2. Your authorization token\n",
-    "\n",
-    "These can be found by navigating to the **Settings** page of your Fiddler environment."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a41e2e8d",
-   "metadata": {
-    "id": "a41e2e8d"
-   },
-   "outputs": [],
-   "source": [
-    "URL = ''  # Make sure to include the full URL (including https://).\n",
-    "TOKEN = ''"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "024b0fda",
-   "metadata": {
-    "id": "024b0fda"
-   },
-   "source": [
-    "Now just run the following code block to connect to the Fiddler API!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "627e583c",
-   "metadata": {
-    "id": "627e583c"
-   },
-   "outputs": [],
-   "source": [
-    "fdl.init(\n",
-    "    url=URL,\n",
-    "    token=TOKEN\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3c513f82",
-   "metadata": {
-    "id": "3c513f82"
-   },
-   "source": [
-    "Once you connect, you can create a new project by calling a Project's `create` method."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b3db485e",
-   "metadata": {
-    "id": "b3db485e"
-   },
-   "outputs": [],
-   "source": [
-    "PROJECT_NAME = 'image_monitoring'\n",
-    "\n",
-    "project = fdl.Project(\n",
-    "    name=PROJECT_NAME\n",
-    ")\n",
-    "\n",
-    "project.create()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "19011830",
-   "metadata": {
-    "id": "19011830"
-   },
-   "source": [
-    "## 2. Generate Embeddings for CIFAR-10 data\n",
-    "\n",
-    "In this example, we'll use the popular CIFAR-10 classification dataset and a model based on Resnet-18 architecture. For the purpose of this example we have pre-trained the model. If you'd like to retrain the model you can use the script located here [TODO: Add link]\n",
-    "  \n",
-    "In order to compute data and prediction drift, **Fiddler needs a sample of data that can serve as a baseline** for making comparisons with data in production. When it comes to computing distributional shift for images, Fiddler relies on the model's intermediate representations also known as activations or embeddings. You can read more about our approach [here](https://www.fiddler.ai/blog/monitoring-natural-language-processing-and-computer-vision-models-part-1).\n",
-    "\n",
-    "In the the following cells we'll extract these embeddings."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6db22a69",
-   "metadata": {
-    "id": "6db22a69"
-   },
-   "outputs": [],
-   "source": [
-    "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
-    "print(f'Device to be used: {device}')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "94ecb2a6",
-   "metadata": {
-    "id": "94ecb2a6"
-   },
-   "source": [
-    "Let us load the pre-trained model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "94f288a2",
-   "metadata": {
-    "id": "94f288a2"
-   },
-   "outputs": [],
-   "source": [
-    "MODEL_URL='https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/models/resnet18_cifar10_epoch5.pth'\n",
-    "MODEL_PATH='resnet18_cifar10_epoch5.pth'\n",
-    "\n",
-    "def load_model(device):\n",
-    "    \"\"\"Loads the pre-trained CIFAR-10 model\"\"\"\n",
-    "    model = resnet18()\n",
-    "    model.fc = nn.Sequential(\n",
-    "        nn.Linear(512, 128),\n",
-    "        nn.ReLU(),\n",
-    "        nn.Linear(128, 10),\n",
-    "    )\n",
-    "\n",
-    "    r = requests.get(MODEL_URL)\n",
-    "    with open(MODEL_PATH,'wb') as f:\n",
-    "        f.write(r.content)\n",
-    "\n",
-    "    model.load_state_dict(torch.load(MODEL_PATH, map_location=torch.device(device)))\n",
-    "    model.to(device)\n",
-    "    return model\n",
-    "\n",
-    "resnet_model = load_model(device)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1ad83d0d",
-   "metadata": {
-    "id": "1ad83d0d"
-   },
-   "source": [
-    "We'll need the CIFAR-10 dataloaders for this example. Note that running the cell below will download the CIFAR-10 data and load them using torch's dataloaders."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b9a635c3",
-   "metadata": {
-    "id": "b9a635c3"
-   },
-   "outputs": [],
-   "source": [
-    "image_transforms = transforms.Compose(\n",
-    "    [\n",
-    "        transforms.ToTensor(),\n",
-    "        transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),\n",
-    "    ]\n",
-    ")\n",
-    "batch_size = 32\n",
-    "trainset = torchvision.datasets.CIFAR10(\n",
-    "    root='./cifar10_data',\n",
-    "    train=True,\n",
-    "    download=True,\n",
-    "    transform=image_transforms\n",
-    ")\n",
-    "trainloader = torch.utils.data.DataLoader(\n",
-    "    trainset,\n",
-    "    batch_size=batch_size,\n",
-    "    shuffle=True,\n",
-    "    num_workers=2\n",
-    ")\n",
-    "\n",
-    "testset = torchvision.datasets.CIFAR10(\n",
-    "    root='./cifar10_data',\n",
-    "    train=False,\n",
-    "    download=True,\n",
-    "    transform=image_transforms\n",
-    ")\n",
-    "testloader = torch.utils.data.DataLoader(\n",
-    "    testset,\n",
-    "    batch_size=batch_size,\n",
-    "    shuffle=False,\n",
-    "    num_workers=2\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f6effa9e",
-   "metadata": {
-    "id": "f6effa9e"
-   },
-   "source": [
-    "***In the cell below we define functions that will extract the 128-dimensional embedding from the FC1 layer of the model***"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9077f38f",
-   "metadata": {
-    "id": "9077f38f"
-   },
-   "outputs": [],
-   "source": [
-    "from copy import deepcopy\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "import torch\n",
-    "import torch.nn.functional as F\n",
-    "import torchvision.transforms as transforms\n",
-    "\n",
-    "torch.manual_seed(0)\n",
-    "\n",
-    "CIFAR_CLASSES = (\n",
-    "    'plane', 'car', 'bird', 'cat',\n",
-    "    'deer', 'dog', 'frog',\n",
-    "    'horse', 'ship', 'truck',\n",
-    ")\n",
-    "\n",
-    "global view_fc1_output_embeds\n",
-    "\n",
-    "def fc1_hook_func(model, input, output):\n",
-    "    global view_fc1_output_embeds\n",
-    "    view_fc1_output_embeds = output\n",
-    "\n",
-    "def idx_to_classes(target_arr):\n",
-    "    return [CIFAR_CLASSES[int(i)] for i in target_arr]\n",
-    "\n",
-    "def generate_embeddings(model, device, dataloader, n=100_000):\n",
-    "    \"\"\"Generate embeddings for the inout images\"\"\"\n",
-    "    with torch.no_grad():\n",
-    "        model = model.eval()\n",
-    "        fc1_module = model.fc[0]\n",
-    "        fc1_hook = fc1_module.register_forward_hook(fc1_hook_func)\n",
-    "        correct_preds = 0\n",
-    "        images_processed = 0\n",
-    "        try:\n",
-    "            for i, (inputs, labels) in enumerate(dataloader):\n",
-    "                inputs = inputs.to(device)\n",
-    "                labels = labels.to(device)\n",
-    "                outputs = model(inputs)\n",
-    "                outputs_smax = F.softmax(outputs, dim=1)\n",
-    "                _, preds = torch.max(outputs, 1)\n",
-    "                correct_preds += torch.sum(preds == labels.data)\n",
-    "                if i == 0:\n",
-    "                    fc1_embeds = view_fc1_output_embeds.cpu().detach().numpy()\n",
-    "                    output_scores = outputs_smax.cpu().detach().numpy()\n",
-    "                    target = labels.cpu().detach().numpy()\n",
-    "                else:\n",
-    "                    fc1_embeds = np.concatenate((fc1_embeds, view_fc1_output_embeds.cpu().detach().numpy()))\n",
-    "                    output_scores = np.concatenate((output_scores, outputs_smax.cpu().detach().numpy()))\n",
-    "                    target = np.concatenate((target, labels.cpu().detach().numpy()))\n",
-    "                images_processed += outputs.size(0)\n",
-    "                if images_processed >= n:\n",
-    "                    break\n",
-    "        except Exception as e:\n",
-    "            fc1_hook.remove()\n",
-    "            raise\n",
-    "\n",
-    "    embs = deepcopy(fc1_embeds[:n])\n",
-    "    labels = idx_to_classes(target[:n])\n",
-    "    embedding_cols = ['emb_'+str(i) for i in range(128)]\n",
-    "    baseline_embeddings = pd.DataFrame(embs, columns=embedding_cols)\n",
-    "\n",
-    "    columns_to_combine = baseline_embeddings.columns\n",
-    "    baseline_embeddings = baseline_embeddings.apply(lambda row: row[columns_to_combine].tolist(), axis=1).to_frame()\n",
-    "    baseline_embeddings = baseline_embeddings.rename(columns={baseline_embeddings.columns[0]: 'embeddings'})\n",
-    "\n",
-    "    baseline_predictions = pd.DataFrame(output_scores[:n], columns=CIFAR_CLASSES)\n",
-    "    baseline_labels = pd.DataFrame(labels, columns=['target'])\n",
-    "    embeddings_df = pd.concat(\n",
-    "        [baseline_embeddings, baseline_predictions, baseline_labels],\n",
-    "        axis='columns',\n",
-    "        ignore_index=False\n",
-    "    )\n",
-    "    return embeddings_df\n",
-    "\n",
-    "\n",
-    "def get_cifar_transforms():\n",
-    "    image_transforms = transforms.Compose(\n",
-    "        [\n",
-    "            transforms.ToTensor(),\n",
-    "            transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])\n",
-    "        ]\n",
-    "    )\n",
-    "    return image_transforms\n",
-    "\n",
-    "def get_blur_transforms():\n",
-    "    image_transforms = transforms.Compose(\n",
-    "        [\n",
-    "            transforms.GaussianBlur(kernel_size=(3, 3), sigma=(0.1, 2)),\n",
-    "            transforms.ToTensor(),\n",
-    "            transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),\n",
-    "        ]\n",
-    "    )\n",
-    "    return image_transforms\n",
-    "\n",
-    "def get_brightness_transforms():\n",
-    "    image_transforms = transforms.Compose(\n",
-    "        [\n",
-    "            transforms.ColorJitter(brightness=(0.4, 0.6)),\n",
-    "            transforms.ToTensor(),\n",
-    "            transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5]),\n",
-    "        ]\n",
-    "    )\n",
-    "    return image_transforms\n",
-    "\n",
-    "def get_cifar_dataloader(train_data=False, batch_size=32, shuffle_data=False, image_transforms=None):\n",
-    "    if image_transforms is None:\n",
-    "        image_transforms = get_cifar_transforms()\n",
-    "    dataset = torchvision.datasets.CIFAR10(root='./cifar10_data', train=train_data,\n",
-    "                                           download=True, transform=image_transforms)\n",
-    "    dataloader = torch.utils.data.DataLoader(\n",
-    "        dataset,\n",
-    "        batch_size=batch_size,\n",
-    "        shuffle=shuffle_data,\n",
-    "        num_workers=2\n",
-    "    )\n",
-    "    return dataloader\n",
-    "\n",
-    "# functions to show an image\n",
-    "def imshow(img):\n",
-    "    img = img / 2 + 0.5     # unnormalize\n",
-    "    npimg = img.numpy()\n",
-    "    plt.imshow(np.transpose(npimg, (1, 2, 0)))\n",
-    "    plt.show()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "56726d41",
-   "metadata": {
-    "id": "56726d41"
-   },
-   "source": [
-    "We'll now extract the embeddings for training data which will serve as baseline for monitoring."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4b095397",
-   "metadata": {
-    "id": "4b095397"
-   },
-   "outputs": [],
-   "source": [
-    "sample_df = generate_embeddings(resnet_model, device, trainloader)\n",
-    "\n",
-    "# Add a row number as a new column for each cifar10 image and a image_url as hosted by huggingface\n",
-    "sample_df['image_number'] = sample_df.reset_index().index\n",
-    "sample_df['image_url'] = sample_df.apply(\n",
-    "    lambda row: f\"https://datasets-server.huggingface.co/assets/cifar10/--/plain_text/train/{row['image_number']}/img/image.jpg\",\n",
-    "    axis=1\n",
-    ")\n",
-    "sample_df.head(5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "47edf8eb",
-   "metadata": {
-    "id": "47edf8eb"
-   },
-   "source": [
-    "# 4. Add metadata about the model\n",
-    "\n",
-    "Next we must tell Fiddler a bit more about our model.  This is done by by creating defining some information about our model's task, inputs, output, target and which features form the image embedding and then creating a `Model` object.\n",
-    "\n",
-    "Let's first define our Image vector using the API below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "205af1a0",
-   "metadata": {
-    "id": "205af1a0"
-   },
-   "outputs": [],
-   "source": [
-    "image_embedding_feature = fdl.ImageEmbedding(\n",
-    "    name='image_feature',\n",
-    "    source_column='image_url',\n",
-    "    column='embeddings',\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a57898d3",
-   "metadata": {
-    "id": "a57898d3"
-   },
-   "source": [
-    "Now let's define a `ModelSpec` object with information about the columns in our data sample."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4dd70f23-49f2-46a9-96a4-fb3ae341e892",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_spec = fdl.ModelSpec(\n",
-    "    inputs=['embeddings'],\n",
-    "    outputs=CIFAR_CLASSES,\n",
-    "    targets=['target'],\n",
-    "    metadata=['image_url'],\n",
-    "    custom_features=[image_embedding_feature],\n",
-    ")\n",
-    "\n",
-    "timestamp_column = 'timestamp'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "162fcae1-1ad9-4a88-9f20-d13070d45389",
-   "metadata": {},
-   "source": [
-    "Then let's specify some information about the model task."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c5050744-1528-4ba3-954e-1a6306a8d44e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_task = fdl.ModelTask.MULTICLASS_CLASSIFICATION\n",
-    "\n",
-    "task_params = fdl.ModelTaskParams(target_class_order=list(CIFAR_CLASSES))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6a7110b2",
-   "metadata": {
-    "id": "6a7110b2"
-   },
-   "source": [
-    "Then just publish all of this to Fiddler by creating a `Model` object."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "43e75271",
-   "metadata": {
-    "id": "43e75271"
-   },
-   "outputs": [],
-   "source": [
-    "MODEL_NAME = 'resnet18'\n",
-    "\n",
-    "model = fdl.Model.from_data(\n",
-    "    name=MODEL_NAME,\n",
-    "    project_id=fdl.Project.from_name(PROJECT_NAME).id,\n",
-    "    source=sample_df,\n",
-    "    spec=model_spec,\n",
-    "    task=model_task,\n",
-    "    task_params=task_params,\n",
-    "    event_ts_col=timestamp_column\n",
-    ")\n",
-    "\n",
-    "model.create()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "53496a28",
-   "metadata": {
-    "id": "53496a28"
-   },
-   "source": [
-    "# 5. Inject data drift and publish production events\n",
-    "\n",
-    "Next, we'll inject data drift in form of blurring and brightness-reduction. The following cell illustrates these transforms."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fda44427",
-   "metadata": {
-    "id": "fda44427"
-   },
-   "outputs": [],
-   "source": [
-    "drift_xform_lut = {\n",
-    "    'original': None,\n",
-    "    'blurred': get_blur_transforms(),\n",
-    "    'brightness_reduced': get_brightness_transforms(),\n",
-    "}\n",
-    "for drift_type, xform in drift_xform_lut.items():\n",
-    "    cifar_testloader = get_cifar_dataloader(train_data=False, batch_size=32, image_transforms=xform)\n",
-    "    # get some test images\n",
-    "    dataiter = iter(cifar_testloader)\n",
-    "    images, labels = next(dataiter)\n",
-    "\n",
-    "    # show images\n",
-    "    print(f'Image type: {drift_type}')\n",
-    "    imshow(torchvision.utils.make_grid(images))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cff619a6",
-   "metadata": {
-    "id": "cff619a6"
-   },
-   "source": [
-    "### Publish events to Fiddler\n",
-    "\n",
-    "We'll publish events over past 3 weeks.\n",
-    "\n",
-    "- Week 1: We publish CIFAR-10 test set, which would signify no distributional shift\n",
-    "- Week 2: We publish **blurred** CIFAR-10 test set\n",
-    "- Week 3: We publish **brightness reduce** CIFAR-10 test set"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "db89da28",
-   "metadata": {
-    "id": "db89da28"
-   },
-   "outputs": [],
-   "source": [
-    "import time\n",
-    "\n",
-    "for i, drift_type in enumerate(['original', 'blurred', 'brightness_reduced']):\n",
-    "    week_days = 6\n",
-    "    xform = drift_xform_lut[drift_type]\n",
-    "    cifar_testloader = get_cifar_dataloader(train_data=False, batch_size=32, image_transforms=xform)\n",
-    "    prod_df = generate_embeddings(resnet_model, device, cifar_testloader)\n",
-    "    week_offset = (2-i)*7*24*60*60*1e3\n",
-    "    day_offset = 24*60*60*1e3\n",
-    "    print(f'Publishing events with {drift_type} transformation for week {i}.')\n",
-    "    for day in range(week_days):\n",
-    "        now = time.time() * 1000\n",
-    "        timestamp = int(now - week_offset - day*day_offset)\n",
-    "        events_df = prod_df.sample(1000)\n",
-    "        events_df['timestamp'] = timestamp\n",
-    "        model.publish(events_df)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eb57a1fd",
-   "metadata": {
-    "id": "eb57a1fd"
-   },
-   "source": [
-    "## 6. Get insights\n",
-    "\n",
-    "**You're all done!**\n",
-    "  \n",
-    "You can now head to Fiddler URL and start getting enhanced observability into your model's performance."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "45cebc85",
-   "metadata": {
-    "id": "45cebc85"
-   },
-   "source": [
-    "Fiddler can now track your image drift over time based on the embedding vectors of the images published into the platform.  Please visit your Fiddler environment upon completion to check this out for yourself."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c9dd52c2-8df7-427a-aa65-cde58eb07e43",
-   "metadata": {
-    "id": "c9dd52c2-8df7-427a-aa65-cde58eb07e43"
-   },
-   "source": [
-    "<table>\n",
-    "    <tr>\n",
-    "        <td>\n",
-    "            <img src=\"https://raw.githubusercontent.com/fiddler-labs/fiddler-examples/main/quickstart/images/image_monitoring_1.png\" />\n",
-    "        </td>\n",
-    "    </tr>\n",
-    "</table>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "800aecc2",
-   "metadata": {
-    "id": "800aecc2"
-   },
-   "source": [
-    "\n",
-    "\n",
-    "---\n",
-    "\n",
-    "\n",
-    "**Questions?**  \n",
-    "  \n",
-    "Check out [our docs](https://docs.fiddler.ai/) for a more detailed explanation of what Fiddler has to offer.\n",
-    "\n",
-    "Join our [community Slack](http://fiddler-community.slack.com/) to ask any questions!\n",
-    "\n",
-    "If you're still looking for answers, fill out a ticket on [our support page](https://fiddlerlabs.zendesk.com/) and we'll get back to you shortly."
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
https://fiddlerlabs.atlassian.net/browse/DOC-196

I pretransformed image assets and stored on github so it's now possible to specify urls for reference and drifted data.  This also removed a lot of image transformation code from the example notebook which simplified it considerably.  I also updated the images at the end to include information on how to use UMAP to RCA embedding drift. This example hasn't worked since we added UMAP to the platform, so this unlocks some really nice additional capability.

Please take it for a spin and proofread my updated notebook copy before we merge to master.

You can test on Colab [here](https://colab.research.google.com/github/fiddler-labs/fiddler-examples/blob/add_cv_monitoring_assets/quickstart/latest/Fiddler_Quickstart_Image_Monitoring.ipynb)
