### PR TITLE
Add new quickstart for evaluating llm data

### DIFF
--- a/quickstart/latest/Fiddler_Quickstart_LLM_Evaluation.ipynb
+++ b/quickstart/latest/Fiddler_Quickstart_LLM_Evaluation.ipynb
@@ -1,0 +1,454 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fiddler LLM Evaluation Quick Start Guide\n",
+    "\n",
+    "Fiddler is the pioneer in enterprise AI Observability, offering a unified platform that enables all model stakeholders to monitor model performance and to investigate the true source of model degredation.  Fiddler's AI Observability platform supports both traditional ML models as well as Generative AI applications.  This guide walks you through how to onboard an LLM chatbot application that is built using a RAG architecture in order to compare two sets of data from two different apis from OpenAi and Anthropic.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "You can start using Fiddler ***in minutes*** by following these 8 quick steps:\n",
+    "\n",
+    "1. Connect to Fiddler\n",
+    "2. Create a Fiddler Project\n",
+    "3. Load a Data Sample\n",
+    "4. Opt-in to Specific Fiddler LLM Enrichments\n",
+    "5. Add Information About the LLM Application\n",
+    "6. Publish Events for Comparison\n",
+    "\n",
+    "Get insights!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fiddler LLM Evaluation Quick Start Guide\n",
+    "\n",
+    "Fiddler is the pioneer in enterprise AI Observability, offering a unified platform that enables all model stakeholders to monitor model performance and to investigate the true source of model degredation.  Fiddler's AI Observability platform supports both traditional ML models as well as Generative AI applications.  This guide walks you through how to onboard an LLM chatbot application that is built using a RAG architecture in order to compare two sets of data from two different apis from OpenAi and Anthropic.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "You can start using Fiddler ***in minutes*** by following these 8 quick steps:\n",
+    "\n",
+    "1. Connect to Fiddler\n",
+    "2. Create a Fiddler Project\n",
+    "3. Load a Data Sample\n",
+    "4. Opt-in to Specific Fiddler LLM Enrichments\n",
+    "5. Add Information About the LLM Application\n",
+    "\n",
+    "6. Publish Production Events\n",
+    "\n",
+    "Get insights!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 0. Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-07-27T19:02:01.749620Z",
+     "start_time": "2023-07-27T19:01:56.285723Z"
+    },
+    "id": "Pg-BdRJ4w3LM"
+   },
+   "outputs": [],
+   "source": [
+    "%pip install -q fiddler-client\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import fiddler as fdl\n",
+    "\n",
+    "print(f\"Running Fiddler Python client version {fdl.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Connect to Fiddler\n",
+    "\n",
+    "Before you can add information about your LLM Application with Fiddler, you'll need to connect using the Fiddler Python client.\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n",
+    "**We need a couple pieces of information to get started.**\n",
+    "1. The URL you're using to connect to Fiddler\n",
+    "2. Your authorization token\n",
+    "\n",
+    "Your authorization token can be found by navigating to the **Credentials** tab on the **Settings** page of your Fiddler environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-07-27T19:02:01.753366Z",
+     "start_time": "2023-07-27T19:02:01.751323Z"
+    },
+    "id": "05hPBZHr1eBv"
+   },
+   "outputs": [],
+   "source": [
+    "URL = ''  # Make sure to include the full URL (including https:// e.g. 'https://your_company_name.fiddler.ai').\n",
+    "TOKEN = ''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Constants for this example notebook, change as needed to create your own versions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PROJECT_NAME = 'quickstart_examples'  # If the project already exists, the notebook will create the model under the existing project.\n",
+    "MODEL_NAME = 'fiddler_llm_app_evaluation'\n",
+    "\n",
+    "OPENAI_NAME = 'openai_dataset'\n",
+    "ANTHROPIC_NAME = 'anthropic_dataset'\n",
+    "\n",
+    "# Sample data hosted on GitHub\n",
+    "PATH_TO_CSV = 'https://media.githubusercontent.com/media/fiddler-labs/fiddler-examples/main/quickstart/data/v3/chatbot_production_data.csv'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now just run the following code block to connect to the Fiddler API!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-07-27T19:02:58.459534Z",
+     "start_time": "2023-07-27T19:02:57.976152Z"
+    },
+    "id": "g6ONUHliBAsH"
+   },
+   "outputs": [],
+   "source": [
+    "fdl.init(url=URL, token=TOKEN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Create a Fiddler Project\n",
+    "\n",
+    "Once you connect, you can create a new project by specifying a unique project name in the `Project` constructor and calling the `create()` method. If the project already exists, it will load it for use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-07-27T18:54:19.978019Z",
+     "start_time": "2023-07-27T18:54:19.874012Z"
+    },
+    "id": "raH7eU2Koaai",
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    # Create project\n",
+    "    project = fdl.Project(name=PROJECT_NAME).create()\n",
+    "    print(f'New project created with id = {project.id} and name = {project.name}')\n",
+    "except fdl.Conflict:\n",
+    "    # Get project by name\n",
+    "    project = fdl.Project.from_name(name=PROJECT_NAME)\n",
+    "    print(f'Loaded existing project with id = {project.id} and name = {project.name}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Opt-in to Specific Fiddler LLM Enrichments\n",
+    "\n",
+    "After picking a sample of our chatbot's prompts and responses, we can request that Fiddler execute a series of enrichment services that can \"score\" our prompts and responses for a variety of insights.  These enrichment services can detect AI safety issues like PII leakage, hallucinations, toxicity, and more.  We can also opt-in for enrichment services like embedding generation which will allow us to track prompt and response outliers and drift. A full description of these enrichments can be found [here](https://docs.fiddler.ai/platform-guide/llm-monitoring/enrichments-private-preview).\n",
+    "\n",
+    "---\n",
+    "Define a list of Fiddler AI backend enrichments for various aspects of the model's input and output, including text embeddings, sentiment analysis, and PII detection. Each enrichment is represented by an appropriate Fiddler API enrichment object, such as TextEmbedding or Enrichment, with associated configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "kJmCV_40oaan"
+   },
+   "outputs": [],
+   "source": [
+    "fiddler_backend_enrichments = [\n",
+    "    # Generate text embeddings for the prompt (question) column\n",
+    "    fdl.TextEmbedding(\n",
+    "        name='Prompt TextEmbedding',\n",
+    "        source_column='question',\n",
+    "        column='Enrichment Prompt Embedding',\n",
+    "        n_tags=10,\n",
+    "    ),\n",
+    "    # Generate text embeddings for the response column\n",
+    "    fdl.TextEmbedding(\n",
+    "        name='Response TextEmbedding',\n",
+    "        source_column='response',\n",
+    "        column='Enrichment Response Embedding',\n",
+    "        n_tags=10,\n",
+    "    ),\n",
+    "    # Generate text embeddings for the source documents (rag documents) column\n",
+    "    fdl.TextEmbedding(\n",
+    "        name='Source Docs TextEmbedding',\n",
+    "        source_column='source_docs',\n",
+    "        column='Enrichment Source Docs Embedding',\n",
+    "        n_tags=10,\n",
+    "    ),\n",
+    "    # Enrichment to assess response faithfulness using source docs and the response\n",
+    "    fdl.Enrichment(\n",
+    "        name='Faithfulness',\n",
+    "        enrichment='ftl_response_faithfulness',\n",
+    "        columns=['source_docs', 'response'],\n",
+    "        config={'context_field': 'source_docs', 'response_field': 'response'},\n",
+    "    ),\n",
+    "    # Perform sentiment analysis on the question and response columns\n",
+    "    fdl.Enrichment(\n",
+    "        name='Enrichment QA Sentiment',\n",
+    "        enrichment='sentiment',\n",
+    "        columns=['question', 'response'],\n",
+    "    ),\n",
+    "    # Detect personally identifiable information (PII) in the question column\n",
+    "    fdl.Enrichment(\n",
+    "        name='Rag PII', enrichment='pii', columns=['question'], allow_list=['fiddler']\n",
+    "    ),\n",
+    "]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5.  Add Information About the LLM application\n",
+    "\n",
+    "Now it's time to onboard information about our LLM application to Fiddler.  We do this by defining a `ModelSpec` object.\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n",
+    "The `ModelSpec` object will contain some **information about how your LLM application operates**.\n",
+    "  \n",
+    "*Just include:*\n",
+    "1. The **input/output** columns.  For a LLM application, these are just the raw inputs and outputs of our LLM application.\n",
+    "2. Any **metadata** columns. Make sure to include the 'model' column we generated earlier. \n",
+    "3. The **custom features** which contain the configuration of the enrichments we opted for.\n",
+    "\n",
+    "We'll also want the **task** your model or LLM application is performing (LLM, regression, binary classification, not set, etc.)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_spec = fdl.ModelSpec(\n",
+    "    inputs=['question', 'response', 'source_docs'],\n",
+    "    metadata=['session_id', 'comment', 'timestamp', 'feedback', 'model'],\n",
+    "    custom_features=fiddler_backend_enrichments,\n",
+    ")\n",
+    "\n",
+    "model_task = fdl.ModelTask.LLM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then just publish all of this to Fiddler by configuring a Model object to represent your LLM application in Fiddler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm_application = fdl.Model.from_data(\n",
+    "    source=df1.head(100),\n",
+    "    name=MODEL_NAME,\n",
+    "    project_id=project.id,\n",
+    "    spec=model_spec,\n",
+    "    task=model_task,\n",
+    "    max_cardinality=5,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now call the create method to publish it to Fiddler!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "llm_application.create()\n",
+    "print(\n",
+    "    f'New model created with id = {llm_application.id} and name = {llm_application.name}'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Publish Events for Comparison\n",
+    "\n",
+    "Information about your LLM application is now onboarded to Fiddler. It's time to start publishing some data to the preproduction environment for comparison!\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n",
+    "Each record sent to Fiddler is called **an event**.  Events simply contain the inputs and outputs of a predictive model or LLM application.\n",
+    "  \n",
+    "Let's load in some sample events (prompts and responses) from our dummy OpenAI and Anthropic datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "publish_job_df1 = llm_application.publish(\n",
+    "    source=df1,\n",
+    "    environment=fdl.EnvType.PRE_PRODUCTION,\n",
+    "    dataset_name=OPENAI_NAME,\n",
+    ")\n",
+    "\n",
+    "# Print the Job ID for tracking\n",
+    "print(f'Initiated pre-production environment data upload with Job ID = {publish_job_df1.id}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, load the second dataset for comparison with the first. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "0HA3zidgoaao"
+   },
+   "outputs": [],
+   "source": [
+    "publish_job_df2 = llm_application.publish(\n",
+    "    source=df2,\n",
+    "    environment=fdl.EnvType.PRE_PRODUCTION,\n",
+    "    dataset_name=ANTHROPIC_NAME,\n",
+    ")\n",
+    "\n",
+    "# Print the Job ID for tracking\n",
+    "print(f'Initiated pre-production environment data upload with Job ID = {publish_job_df2.id}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Get insights\n",
+    "\n",
+    "**You're all done!**\n",
+    "\n",
+    "You can now head to your Fiddler environment and start getting enhanced observability into your LLM application's performance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Get insights\n",
+    "\n",
+    "**You're all done!**\n",
+    "\n",
+    "You can now head to your Fiddler environment and start getting enhanced observability into your LLM application's performance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**What's Next?**\n",
+    "\n",
+    "Try the [ML Monitoring - Quick Start Guide](https://docs.fiddler.ai/quickstart-notebooks/quick-start)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n",
+    "**Questions?**  \n",
+    "  \n",
+    "Check out [our docs](https://docs.fiddler.ai/) for a more detailed explanation of what Fiddler has to offer.\n",
+    "\n",
+    "Join our [community Slack](http://fiddler-community.slack.com/) to ask any questions!\n",
+    "\n",
+    "If you're still looking for answers, fill out a ticket on [our support page](https://fiddlerlabs.zendesk.com/) and we'll get back to you shortly."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This quickstart is to help users understand how to publish multiple data sources to pre production for comparison. In this case dummy OpenAI and Anthropic prompt/response datasets. 