### PR TITLE
Add query custom metric for FQL testing

### DIFF
--- a/misc-utils/README.md
+++ b/misc-utils/README.md
@@ -583,6 +583,7 @@ These notebooks demonstrate practical solutions for common Fiddler administrativ
 - `validate_and_preview_metric()` - Complete validation workflow
 - `batch_test_metrics()` - Test multiple definitions efficiently
 - `cleanup_orphaned_test_metrics()` - Remove leftover test metrics
+- `query_custom_metric()` - Get the value of custom metric on previously published data
 
 **Use cases:**
 - **Cross-model migration:** Copy custom metrics/segments between models with different schemas

--- a/misc-utils/fql_utilities_demo.ipynb
+++ b/misc-utils/fql_utilities_demo.ipynb
@@ -101,12 +101,12 @@
     "from typing import Dict, Set\n",
     "\n",
     "import fiddler as fdl\n",
-    "\n",
+    "# Add parent directory to path to import fiddler_utils\n",
+    "sys.path.insert(0, \"..\")\n",
     "from fiddler_utils import fql\n",
     "from fiddler_utils.connection import get_or_init\n",
     "\n",
-    "# Add parent directory to path to import fiddler_utils\n",
-    "sys.path.insert(0, \"..\")\n",
+    "\n",
     "\n",
     "print(\"✓ Imports successful\")\n"
    ]
@@ -1653,6 +1653,7 @@
     "    test_metric_definition,\n",
     "    validate_and_preview_metric,\n",
     "    validate_metric_syntax_local,\n",
+    "    query_custom_metric,\n",
     ")\n",
     "\n",
     "print(\"✓ FQL testing utilities imported\")"
@@ -1786,6 +1787,100 @@
     "    print()\n",
     "    print(\"This is the ONLY way to truly validate FQL!\")\n",
     "    print(\"Local validation cannot test tp(), fp(), jsd(), etc.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6.3.1 Query the Value of the FQL Custom Metric\n",
+    "\n",
+    "This step requires that data has already been published into Fiddler (whether pre-production or production data)\n",
+    "\n",
+    "Once a custom metric is created, you can query Fiddler's metric API to get the value of the custom metric and compare to expected ground truth (if available or can calculate externally for validation).\n",
+    "\n",
+    "You can iterate through many defined custom metrics (or variations of them) and compare with expected values to quickly update/refine FQL calculations against previously published pre-production or production data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    " # Let's use the first metric from the list and peek its definition\n",
+    " # This can be any custom metric that's been created/validated for syntax above\n",
+    "if URL and TOKEN and model:\n",
+    "    custom_metrics = list(fdl.CustomMetric.list(model_id=model.id))\n",
+    "    metric = custom_metrics[0]\n",
+    "    print(\"Metric Name: \", metric.name)\n",
+    "    print(\"Metric ID: \", metric.definition)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OPTION 1: Use pre-production or baseline dataset for evaluation\n",
+    "baseline_name = 'bank_churn_baseline2' # Or replace with your baseline name  \n",
+    "\n",
+    "# Call function to query the value of the custom metric for pre-production data\n",
+    "result = query_custom_metric(\n",
+    "    metric=metric,\n",
+    "    model=model,\n",
+    "    url=URL,\n",
+    "    token=TOKEN,\n",
+    "    baseline_name=baseline_name,\n",
+    ")\n",
+    "\n",
+    "print(f\"Evaluating custom metric on pre-production baseline: \\\"{baseline_name}\\\"\")\n",
+    "print(\"Metric Name: \", metric.name)\n",
+    "print(\"Metric Value: \", result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OPTION 2: Use a time range for previously published production data\n",
+    "from datetime import datetime, timedelta\n",
+    "\n",
+    "start_time_published_data = str(datetime.now() - timedelta(days=7))\n",
+    "end_time_published_data = str(datetime.now() - timedelta(days=6))\n",
+    "print(\"Start of Time of Published Data: \", start_time_published_data)\n",
+    "print(\"End of Time of Published Data: \", end_time_published_data)\n",
+    "\n",
+    "# Call function to query the value of the custom metric for time window of production data\n",
+    "result = query_custom_metric(\n",
+    "    metric=metric,\n",
+    "    model=model,\n",
+    "    url=URL,\n",
+    "    token=TOKEN,\n",
+    "    start_time=start_time_published_data,\n",
+    "    end_time=end_time_published_data,\n",
+    ")\n",
+    "\n",
+    "print(\"Metric Name: \", metric.name)\n",
+    "print(\"Metric Value: \", result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If you have an expected or ground truth value, you can compare the result to it\n",
+    "# and iterate through many defined custom metrics to quickly refine/update FQL calculations\n",
+    "\n",
+    "expected_value = 0.92 # Replace with your expected value\n",
+    "print(\"Expected Value: \", round(expected_value, 2))\n",
+    "print(\"Calculated Metric Value: \", round(result, 2))\n",
+    "print(\"Difference: \", round(abs(result - expected_value), 2))"
    ]
   },
   {

--- a/misc-utils/fql_utilities_demo.ipynb
+++ b/misc-utils/fql_utilities_demo.ipynb
@@ -1814,7 +1814,7 @@
     "    custom_metrics = list(fdl.CustomMetric.list(model_id=model.id))\n",
     "    metric = custom_metrics[0]\n",
     "    print(\"Metric Name: \", metric.name)\n",
-    "    print(\"Metric ID: \", metric.definition)"
+    "    print(\"Metric Definition: \", metric.definition)"
    ]
   },
   {


### PR DESCRIPTION
Add section 6.3.1 to the [misc-utils/fql_utilities_demo.ipynb](https://github.com/fiddler-labs/fiddler-examples/compare/update-fdl-demo?expand=1#diff-8dc02f896a7dda99314d484579b85cfbf2552d5817932451cec2f5bc6589e4b7)

Adds ability to query our metric API to quickly evaluate/iterate on FQL custom metric definitions: [fiddler_utils/testing.py:524](https://github.com/fiddler-labs/fiddler-examples/blob/c54ca5fa0e79ee1c1d1dfac7461eee2c7572c192/fiddler_utils/testing.py#L524)