### PR TITLE
Add Google ADK quickstart notebook

### DIFF
--- a/quickstart/latest/Fiddler_Quickstart_Google_ADK_Integration.ipynb
+++ b/quickstart/latest/Fiddler_Quickstart_Google_ADK_Integration.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q fiddler-adk google-adk"
+    "%pip install -q fiddler-adk google-adk"
    ]
   },
   {
@@ -83,8 +83,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fiddler_otel import FiddlerClient\n",
     "from fiddler_adk import GoogleADKInstrumentor\n",
+    "from fiddler_otel import FiddlerClient\n",
     "\n",
     "client = FiddlerClient(\n",
     "    api_key=FIDDLER_API_KEY,\n",
@@ -190,7 +190,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import asyncio\n",
     "from google.adk.runners import Runner\n",
     "from google.adk.sessions import InMemorySessionService\n",
     "from google.genai import types\n",
@@ -284,13 +283,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "fiddler-documentation-manager (3.13.3)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.13.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/quickstart/latest/Fiddler_Quickstart_Google_ADK_Integration.ipynb
+++ b/quickstart/latest/Fiddler_Quickstart_Google_ADK_Integration.ipynb
@@ -1,0 +1,298 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fiddler Quickstart: Google ADK Integration\n",
+    "\n",
+    "This notebook demonstrates how to instrument a Google ADK (Agent Development Kit) agent with Fiddler for comprehensive observability.\n",
+    "\n",
+    "**What you'll learn:**\n",
+    "- Install and configure `fiddler-adk`\n",
+    "- Instrument an ADK agent with tools\n",
+    "- Run multi-turn conversations\n",
+    "- View traces in the Fiddler UI\n",
+    "\n",
+    "**Time to complete:** ~10 minutes\n",
+    "\n",
+    "**Prerequisites:**\n",
+    "- Fiddler account with API key and Application ID\n",
+    "- Google Gemini API key or Vertex AI credentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Install Dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q fiddler-adk google-adk"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Configure Credentials\n",
+    "\n",
+    "Replace the placeholder values below with your actual credentials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "# Fiddler credentials\n",
+    "FIDDLER_URL = \"https://your-fiddler-instance.com\"       # Your Fiddler instance URL\n",
+    "FIDDLER_API_KEY = \"your-fiddler-api-key\"                # From Fiddler Settings\n",
+    "FIDDLER_APPLICATION_ID = \"your-application-uuid\"        # From GenAI Applications page\n",
+    "\n",
+    "# Google credentials (choose one)\n",
+    "os.environ[\"GOOGLE_API_KEY\"] = \"your-gemini-api-key\"    # Option A: Gemini API key\n",
+    "\n",
+    "# Option B: Vertex AI (uncomment below, comment out GOOGLE_API_KEY above)\n",
+    "# os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"1\"\n",
+    "# os.environ[\"GOOGLE_CLOUD_PROJECT\"] = \"your-gcp-project\"\n",
+    "# os.environ[\"GOOGLE_CLOUD_LOCATION\"] = \"us-central1\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Set Up Fiddler Instrumentation\n",
+    "\n",
+    "Two lines to enable automatic tracing for all ADK agents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fiddler_otel import FiddlerClient\n",
+    "from fiddler_adk import GoogleADKInstrumentor\n",
+    "\n",
+    "client = FiddlerClient(\n",
+    "    api_key=FIDDLER_API_KEY,\n",
+    "    application_id=FIDDLER_APPLICATION_ID,\n",
+    "    url=FIDDLER_URL,\n",
+    ")\n",
+    "GoogleADKInstrumentor(client).instrument()\n",
+    "\n",
+    "print(\"Fiddler instrumentation enabled!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Define Tools\n",
+    "\n",
+    "Create tools that the agent can use. Tool calls are automatically traced."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_weather(city: str) -> dict:\n",
+    "    \"\"\"Get current weather for a city.\n",
+    "\n",
+    "    Args:\n",
+    "        city: The city name to get weather for.\n",
+    "\n",
+    "    Returns:\n",
+    "        A dict with temperature and conditions.\n",
+    "    \"\"\"\n",
+    "    weather_data = {\n",
+    "        \"San Francisco\": {\"temp_f\": 62, \"condition\": \"foggy\"},\n",
+    "        \"New York\": {\"temp_f\": 78, \"condition\": \"sunny\"},\n",
+    "        \"London\": {\"temp_f\": 58, \"condition\": \"rainy\"},\n",
+    "    }\n",
+    "    data = weather_data.get(city, {\"temp_f\": 72, \"condition\": \"clear\"})\n",
+    "    return {\"city\": city, **data}\n",
+    "\n",
+    "\n",
+    "def convert_temperature(temp_f: float, to_unit: str) -> dict:\n",
+    "    \"\"\"Convert temperature between Fahrenheit and Celsius.\n",
+    "\n",
+    "    Args:\n",
+    "        temp_f: Temperature in Fahrenheit.\n",
+    "        to_unit: Target unit ('celsius' or 'fahrenheit').\n",
+    "\n",
+    "    Returns:\n",
+    "        A dict with the converted temperature.\n",
+    "    \"\"\"\n",
+    "    if to_unit.lower() == \"celsius\":\n",
+    "        return {\"temp\": round((temp_f - 32) * 5 / 9, 1), \"unit\": \"C\"}\n",
+    "    return {\"temp\": temp_f, \"unit\": \"F\"}\n",
+    "\n",
+    "\n",
+    "print(\"Tools defined: get_weather, convert_temperature\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5: Create the Agent\n",
+    "\n",
+    "Create a Gemini-powered agent with the tools attached."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from google.adk.agents.llm_agent import Agent\n",
+    "\n",
+    "agent = Agent(\n",
+    "    model=\"gemini-2.5-flash\",\n",
+    "    name=\"weather_agent\",\n",
+    "    description=\"A helpful weather assistant\",\n",
+    "    instruction=\"You help users check the weather. Use the tools available to get weather data and convert temperatures. Be concise.\",\n",
+    "    tools=[get_weather, convert_temperature],\n",
+    ")\n",
+    "\n",
+    "print(f\"Agent '{agent.name}' created with {len(agent.tools)} tools\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Run the Agent\n",
+    "\n",
+    "Run a multi-turn conversation. Each turn creates a trace in Fiddler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asyncio\n",
+    "from google.adk.runners import Runner\n",
+    "from google.adk.sessions import InMemorySessionService\n",
+    "from google.genai import types\n",
+    "\n",
+    "\n",
+    "async def run_conversation():\n",
+    "    session_service = InMemorySessionService()\n",
+    "    runner = Runner(\n",
+    "        agent=agent, app_name=\"weather_demo\", session_service=session_service\n",
+    "    )\n",
+    "    session = await session_service.create_session(\n",
+    "        app_name=\"weather_demo\", user_id=\"notebook_user\"\n",
+    "    )\n",
+    "\n",
+    "    # Multi-turn conversation\n",
+    "    prompts = [\n",
+    "        \"What's the weather in San Francisco?\",\n",
+    "        \"Convert that temperature to Celsius\",\n",
+    "        \"How about New York?\",\n",
+    "    ]\n",
+    "\n",
+    "    for prompt in prompts:\n",
+    "        print(f\"\\nUser: {prompt}\")\n",
+    "        message = types.Content(\n",
+    "            role=\"user\", parts=[types.Part(text=prompt)]\n",
+    "        )\n",
+    "\n",
+    "        async for event in runner.run_async(\n",
+    "            user_id=\"notebook_user\",\n",
+    "            session_id=session.id,\n",
+    "            new_message=message,\n",
+    "        ):\n",
+    "            if hasattr(event, \"content\") and event.content:\n",
+    "                parts = getattr(event.content, \"parts\", []) or []\n",
+    "                text = \"\".join(\n",
+    "                    p.text for p in parts if getattr(p, \"text\", None)\n",
+    "                )\n",
+    "                if text:\n",
+    "                    print(f\"Agent: {text}\")\n",
+    "\n",
+    "\n",
+    "await run_conversation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 7: Flush Traces\n",
+    "\n",
+    "Ensure all traces are sent to Fiddler before the notebook ends."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.force_flush(timeout_millis=10000)\n",
+    "print(\"Traces flushed to Fiddler!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 8: View in Fiddler\n",
+    "\n",
+    "Navigate to your Fiddler instance and open your application. In the Trace Explorer you should see:\n",
+    "\n",
+    "- **Agent spans** (`invoke_agent`) — one per turn\n",
+    "- **LLM spans** (`call_llm`) — with input prompt, model response, and system instructions\n",
+    "- **Tool spans** (`execute_tool`) — with tool arguments and return values\n",
+    "- **Token counts** — input, output, and reasoning tokens per LLM call\n",
+    "\n",
+    "Each turn is grouped by session ID for multi-turn conversation tracking."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "- [Google ADK Integration Guide](https://docs.fiddler.ai/integrations/agentic-ai/google-adk-sdk) — Full documentation\n",
+    "- [Fiddler Evals SDK](https://docs.fiddler.ai/integrations/agentic-ai/evals-sdk) — Evaluate agent quality\n",
+    "- [Google ADK Documentation](https://adk.dev) — Learn more about ADK"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Adds a quickstart Jupyter notebook for the `fiddler-adk` Google ADK integration.

`quickstart/latest/Fiddler_Quickstart_Google_ADK_Integration.ipynb`

Covers:
- Install `fiddler-adk` from PyPI
- Configure Fiddler and Google credentials
- Set up instrumentation (2 lines)
- Define tools (get_weather, convert_temperature)
- Create a Gemini-powered agent
- Run a 3-turn conversation
- Flush traces and verify in Fiddler UI

## Related

- Docs PR: https://github.com/fiddler-labs/fiddler/pull/20707
- Issue: https://github.com/fiddler-labs/fiddler/issues/20702