### PR TITLE
docs: pin fiddler-evals>=0.6.0 and use canonical experiment-trace-capture slug

### DIFF
--- a/quickstart/latest/Fiddler_Quickstart_Experiment_Trace_Capture.ipynb
+++ b/quickstart/latest/Fiddler_Quickstart_Experiment_Trace_Capture.ipynb
@@ -62,7 +62,7 @@
    "outputs": [],
    "source": [
     "# Install the Fiddler Evaluations SDK (fiddler-otel comes with it)\n",
-    "%pip install -q --upgrade fiddler-evals\n",
+    "%pip install -q --upgrade \"fiddler-evals>=0.6.0\"\n",
     "\n",
     "import time\n",
     "\n",
@@ -529,7 +529,7 @@
     "\n",
     "### Next steps\n",
     "\n",
-    "- [Capture traces during experiments](https://docs.fiddler.ai/evaluate-and-test/eval-trace-capture)\n",
+    "- [Capture traces during experiments](https://docs.fiddler.ai/evaluate-and-test/experiment-trace-capture)\n",
     "- [Build a golden dataset from production spans](https://docs.fiddler.ai/evaluate-and-test/golden-datasets)\n",
     "- [Evals SDK Quick Start](https://docs.fiddler.ai/evaluate-and-test/evals-sdk-quick-start)\n",
     "\n",

--- a/quickstart/latest/Fiddler_Quickstart_Golden_Datasets.ipynb
+++ b/quickstart/latest/Fiddler_Quickstart_Golden_Datasets.ipynb
@@ -55,7 +55,7 @@
    "outputs": [],
    "source": [
     "# Install the Fiddler Evaluations SDK\n",
-    "%pip install -q --upgrade fiddler-evals\n",
+    "%pip install -q --upgrade \"fiddler-evals>=0.6.0\"\n",
     "\n",
     "# Core imports\n",
     "import json\n",
@@ -991,7 +991,7 @@
     "- [Golden Datasets documentation](https://docs.fiddler.ai/evaluate-and-test/golden-datasets)\n",
     "- [Span and Resource Attributes](https://docs.fiddler.ai/integrations/agentic-ai/attributes) — the full catalog of filterable fields\n",
     "- [Query spans REST reference](https://docs.fiddler.ai/sdk-api/rest-api/spans/query-spans)\n",
-    "- [Capture traces during experiments](https://docs.fiddler.ai/evaluate-and-test/eval-trace-capture)\n",
+    "- [Capture traces during experiments](https://docs.fiddler.ai/evaluate-and-test/experiment-trace-capture)\n",
     "- [Evals SDK Quick Start](https://docs.fiddler.ai/evaluate-and-test/evals-sdk-quick-start)\n",
     "\n",
     "### Questions?\n",


### PR DESCRIPTION
Two strictly-safe fixes to the Golden Datasets and Experiment Trace Capture quickstarts, both merged 7/30:

- **Pin `fiddler-evals>=0.6.0`.** Both notebooks exercise 0.6.0 APIs. On an environment that already has 0.5 installed, Trace Capture silently degrades to all-SKIPPED scores and Golden Datasets fails with `ImportError` — the unpinned `%pip install --upgrade` line doesn't force the floor.
- **Switch the docs link to the canonical `/evaluate-and-test/experiment-trace-capture` slug.** Both notebooks link `/evaluate-and-test/eval-trace-capture`, which has 404'd in production since 7/30. The page ships as `experiment-trace-capture` in fiddler-labs/fiddler#22220 (which also adds a redirect from the old slug), so the canonical link is no worse than today and self-heals when 26.16 goes live.

Raw-JSON edits only; 4 lines changed across the two notebooks. A follow-up PR will align the Golden Datasets prefix-mapping cells with the 26.16 verbatim-key behavior once fiddler-labs/fiddler#22220 is approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
